### PR TITLE
Update CLI and System Settings to display ITSM-NG information rather than GPLI

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -1874,9 +1874,6 @@ class Config extends CommonDBTM {
 
       echo "<table class='tab_cadre_fixe'>";
       echo "<tr><th>". __('Information about system installation and configuration')."</th></tr>";
-      echo "<tr class='tab_bg_1'><td>";
-      echo "<a class='vsubmit' href='?check_version'>".__('Check if a new version is available')."</a>";
-      echo "</td></tr>";
 
        $oldlang = $_SESSION['glpilanguage'];
        // Keep this, for some function call which still use translation (ex showAllReplicateDelay)
@@ -1884,25 +1881,9 @@ class Config extends CommonDBTM {
 
       // No need to translate, this part always display in english (for copy/paste to forum)
 
-      // Try to compute a better version for .git
-      $ver = GLPI_VERSION;
-      if (is_dir(GLPI_ROOT."/.git")) {
-         $dir = getcwd();
-         chdir(GLPI_ROOT);
-         $returnCode = 1;
-         /** @var array $output */
-         $gitrev = @exec('git show --format="%h" --no-patch 2>&1', $output, $returnCode);
-         $gitbranch = '';
-         if (!$returnCode) {
-            $gitbranch = @exec('git symbolic-ref --quiet --short HEAD || git rev-parse --short HEAD 2>&1', $output, $returnCode);
-         }
-         chdir($dir);
-         if (!$returnCode) {
-            $ver .= '-git-' .$gitbranch . '-' . $gitrev;
-         }
-      }
+      $ver = ITSM_VERSION;
       echo "<tr class='tab_bg_1'><td><pre>[code]\n&nbsp;\n";
-      echo "GLPI $ver (" . $CFG_GLPI['root_doc']." => " . GLPI_ROOT . ")\n";
+      echo "ITSM-NG $ver (" . $CFG_GLPI['root_doc']." => " . GLPI_ROOT . ")\n";
       echo "Installation mode: " . GLPI_INSTALL_MODE . "\n";
       echo "Current language:" . $oldlang . "\n";
       echo "\n</pre></td></tr>";

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -1882,7 +1882,7 @@ class Config extends CommonDBTM {
       // No need to translate, this part always display in english (for copy/paste to forum)
 
       $ver = ITSM_VERSION;
-      echo "<tr class='tab_bg_1'><td><pre>[code]\n&nbsp;\n";
+      echo "<tr class='tab_bg_1'><td><pre>\n";
       echo "ITSM-NG $ver (" . $CFG_GLPI['root_doc']." => " . GLPI_ROOT . ")\n";
       echo "Installation mode: " . GLPI_INSTALL_MODE . "\n";
       echo "Current language:" . $oldlang . "\n";

--- a/inc/console/abstractcommand.class.php
+++ b/inc/console/abstractcommand.class.php
@@ -194,7 +194,7 @@ abstract class AbstractCommand extends Command implements GlpiCommandInterface {
       if ($core_requirements->hasMissingOptionalRequirements()) {
          $message = __('Some optional system requirements are missing.')
             . ' '
-            . __('Run "php bin/console glpi:system:check_requirements" for more details.');
+            . __('Run "php bin/console itsmng:system:check_requirements" for more details.');
          $this->output->writeln(
             '<comment>' . $message . '</comment>',
             OutputInterface::VERBOSITY_NORMAL

--- a/inc/console/application.class.php
+++ b/inc/console/application.class.php
@@ -469,7 +469,7 @@ class Application extends BaseApplication {
       if ($core_requirements->hasMissingMandatoryRequirements()) {
          $message = __('Some mandatory system requirements are missing.')
             . ' '
-            . __('Run "php bin/console glpi:system:check_requirements" for more details.');
+            . __('Run "php bin/console itsmng:system:check_requirements" for more details.');
          $this->output->writeln(
             '<error>' . $message . '</error>',
             OutputInterface::VERBOSITY_QUIET

--- a/inc/console/application.class.php
+++ b/inc/console/application.class.php
@@ -98,7 +98,7 @@ class Application extends BaseApplication {
 
    public function __construct() {
 
-      parent::__construct('GLPI CLI', GLPI_VERSION);
+      parent::__construct('ITSM-NG CLI', GLPI_VERSION);
 
       $this->initApplication();
       $this->initDb();

--- a/inc/console/application.class.php
+++ b/inc/console/application.class.php
@@ -98,7 +98,7 @@ class Application extends BaseApplication {
 
    public function __construct() {
 
-      parent::__construct('ITSM-NG CLI', GLPI_VERSION);
+      parent::__construct('ITSM-NG CLI', ITSM_VERSION);
 
       $this->initApplication();
       $this->initDb();

--- a/inc/console/migration/buildmissingtimestampscommand.class.php
+++ b/inc/console/migration/buildmissingtimestampscommand.class.php
@@ -48,7 +48,7 @@ class BuildMissingTimestampsCommand extends AbstractCommand {
    protected function configure() {
       parent::configure();
 
-      $this->setName('glpi:migration:build_missing_timestamps');
+      $this->setName('itsmng:migration:build_missing_timestamps');
       $this->setDescription(__('Set missing `date_creation` and `date_mod` values using log entries.'));
       $this->setHidden(true); // Hide this command as it is when migrating from really old GLPI version
    }


### PR DESCRIPTION
Changed GPLI version displays to display ITSM-NG versions and removed the non functioning auto update feature in system settings.