### PR TITLE
Create a simple license header for new ITSM code

### DIFF
--- a/header.txt
+++ b/header.txt
@@ -1,0 +1,30 @@
+/**
+ *                            - OUR SOFTWARE -
+ *
+ * ITSM-NG - Information Technology Service Management - Next Generation
+ * Copyleft 2022 - ITSM-NG Team
+ *
+ * Website: https://itsm-ng.org
+ *
+ * Forked from GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2022 Teclib' and contributors.
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ *                              - LICENSING -
+ *
+ * This file is part of ITSM-NG.
+ *
+ * ITSM-NG is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * ITSM-NG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with ITSM-NG. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */


### PR DESCRIPTION
I've created a simple header text file that is meant to be used by ITSM-NG contributors to indicate that code is added ITSM.
It's based on the header that was previously used by GLPI so that thing stay consistent.

Feel free to improve this with complementary information if you see fit.