### PR TITLE
Fix issue where a reinstall would fail from a conflict with existing database

### DIFF
--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -8136,6 +8136,7 @@ CREATE TABLE IF NOT EXISTS `glpi_oidc_config` (
         PRIMARY KEY (`id`)
         ) ENGINE=MyISAM  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
+DROP TABLE IF EXISTS `glpi_specialstatuses`;
 CREATE TABLE IF NOT EXISTS `glpi_specialstatuses` (
         `id` int(11) NOT NULL auto_increment,
         `name` varchar(255) DEFAULT NULL,


### PR DESCRIPTION
Added a `DROP TABLE IF EXISTS` directive for the `specialstatuses` table as removing the `config_db` and reinstalling would fail due to a conflict between the existing database and the empty sql file.