### PR TITLE
Introduce accessibility features

### DIFF
--- a/ajax/common.tabs.php
+++ b/ajax/common.tabs.php
@@ -68,6 +68,12 @@ if (isset($_GET['id']) && !empty($_GET['id'])) {
 
 if ($item = getItemForItemtype($_UGET['_itemtype'])) {
    if ($item->get_item_to_display_tab) {
+       Html::
+      echo Html::scriptBlock(''.
+          '$("#shortcut-floater").unbind("click");'.
+          '$("#shortcut-floater").attr("onclick", "alert(\"'.Accessibility::editTabShortcutForm($_GET["_glpi_tab"]).'\")");'
+      );
+
       // No id if ruleCollection but check right
       if ($item instanceof RuleCollection) {
          if (!$item->canList()) {

--- a/ajax/common.tabs.php
+++ b/ajax/common.tabs.php
@@ -68,12 +68,6 @@ if (isset($_GET['id']) && !empty($_GET['id'])) {
 
 if ($item = getItemForItemtype($_UGET['_itemtype'])) {
    if ($item->get_item_to_display_tab) {
-       Html::
-      echo Html::scriptBlock(''.
-          '$("#shortcut-floater").unbind("click");'.
-          '$("#shortcut-floater").attr("onclick", "alert(\"'.Accessibility::editTabShortcutForm($_GET["_glpi_tab"]).'\")");'
-      );
-
       // No id if ruleCollection but check right
       if ($item instanceof RuleCollection) {
          if (!$item->canList()) {

--- a/css/styles.scss
+++ b/css/styles.scss
@@ -7084,7 +7084,8 @@ div.progress {
 /* ====== KEYBOARD SHORTCUTS ====== */
 
 kbd {
-   background-color: #eee;
+   backdrop-filter: blur(1px);
+   background-color: transparent;
    border-radius: 3px;
    border: 1px solid #b4b4b4;
    box-shadow: 0 1px 1px rgba(0, 0, 0, .2), 0 2px 0 0 rgba(255, 255, 255, .7) inset;
@@ -7095,4 +7096,15 @@ kbd {
    line-height: 1;
    padding: 2px 4px;
    white-space: nowrap;
+}
+
+#shortcut-floater {
+   background-color: #e7e7e7;
+   border-radius: 0.2rem;
+   border: 1px solid transparent;
+   padding: 0.1rem 1rem;
+   line-height: 1.5;
+   position: relative;
+   left: 50%;
+   cursor: pointer;
 }

--- a/css/styles.scss
+++ b/css/styles.scss
@@ -7080,3 +7080,19 @@ div.progress {
 .rich_text_container pre, .rich_text_container span {
    white-space: pre-wrap;
 }
+
+/* ====== KEYBOARD SHORTCUTS ====== */
+
+kbd {
+   background-color: #eee;
+   border-radius: 3px;
+   border: 1px solid #b4b4b4;
+   box-shadow: 0 1px 1px rgba(0, 0, 0, .2), 0 2px 0 0 rgba(255, 255, 255, .7) inset;
+   color: #333;
+   display: inline-block;
+   font-size: .85em;
+   font-weight: 700;
+   line-height: 1;
+   padding: 2px 4px;
+   white-space: nowrap;
+}

--- a/front/accessibility.form.php
+++ b/front/accessibility.form.php
@@ -1,3 +1,5 @@
+<?php
+
 /**
  * ---------------------------------------------------------------------
  * ITSM-NG
@@ -28,8 +30,6 @@
  * along with ITSM-NG. If not, see <http://www.gnu.org/licenses/>.
  * ---------------------------------------------------------------------
  */
-
-<?php
 
 if (!defined('GLPI_ROOT')) {
     include ('../inc/includes.php');

--- a/front/accessibility.form.php
+++ b/front/accessibility.form.php
@@ -1,0 +1,15 @@
+<?php
+
+if (!defined('GLPI_ROOT')) {
+    include ('../inc/includes.php');
+}
+
+Html::popHeader(__("Setup"), $_SERVER["PHP_SELF"]);
+
+Session::checkRight("accessibility", READ);
+
+$accessdisplay = new Accessibility();
+
+if (isset($_POST["update"])) {
+
+}

--- a/front/accessibility.form.php
+++ b/front/accessibility.form.php
@@ -1,3 +1,34 @@
+/**
+ * ---------------------------------------------------------------------
+ * ITSM-NG
+ * Copyright (C) 2022 ITSM-NG and contributors.
+ *
+ * https://www.itsm-ng.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of ITSM-NG.
+ *
+ * ITSM-NG is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * ITSM-NG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with ITSM-NG. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
 <?php
 
 if (!defined('GLPI_ROOT')) {

--- a/header.txt
+++ b/header.txt
@@ -1,0 +1,30 @@
+/**
+ *                            - OUR SOFTWARE -
+ *
+ * ITSM-NG - Information Technology Service Management - Next Generation
+ * Copyleft 2022 - ITSM-NG Team
+ *
+ * Website: https://itsm-ng.org
+ *
+ * Forked from GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2022 Teclib' and contributors.
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ *                              - LICENSING -
+ *
+ * This file is part of ITSM-NG.
+ *
+ * ITSM-NG is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * ITSM-NG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with ITSM-NG. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */

--- a/inc/accessibility.class.php
+++ b/inc/accessibility.class.php
@@ -16,15 +16,6 @@ class Accessibility extends CommonDBTM {
 
     /*************************************** TABS ********************************************/
 
-    function defineTabs($options = []) {
-
-        $ong = [];
-        $this->addStandardTab(__CLASS__, $ong, $options);
-        $this->addStandardTab('Log', $ong, $options);
-
-        return $ong;
-    }
-
     function getTabNameForItem(CommonGLPI $item, $withtemplate = 0) {
 
         switch ($item->getType()) {
@@ -67,7 +58,6 @@ class Accessibility extends CommonDBTM {
     function showAccessForm($data = []) {
         global $CFG_GLPI, $DB;
 
-        $oncentral = (Session::getCurrentInterface() == "central");
         $userpref  = false;
         $url       = Toolbox::getItemTypeFormURL(__CLASS__);
         $rand      = mt_rand();

--- a/inc/accessibility.class.php
+++ b/inc/accessibility.class.php
@@ -1,3 +1,5 @@
+<?php
+
 /**
  * ---------------------------------------------------------------------
  * ITSM-NG
@@ -28,8 +30,6 @@
  * along with ITSM-NG. If not, see <http://www.gnu.org/licenses/>.
  * ---------------------------------------------------------------------
  */
-
-<?php
 
 class Accessibility extends CommonDBTM {
     static function getTypeName($nb = 0) {

--- a/inc/accessibility.class.php
+++ b/inc/accessibility.class.php
@@ -1,0 +1,136 @@
+<?php
+
+class Accessibility extends CommonDBTM {
+    static function getTypeName($nb = 0) {
+        return __("Accessibility");
+    }
+
+    function getRights($interface = 'central') {
+        $values[READ] = ["short" => __("Read"),
+            "long" => __("See this parameter in your settings")];
+        $values[UPDATE] = ["short" => __("Edit"),
+            "long" => __("Edit this parameter in your settings")];
+
+        return $values;
+    }
+
+    /*************************************** TABS ********************************************/
+
+    function defineTabs($options = []) {
+
+        $ong = [];
+        $this->addStandardTab(__CLASS__, $ong, $options);
+        $this->addStandardTab('Log', $ong, $options);
+
+        return $ong;
+    }
+
+    function getTabNameForItem(CommonGLPI $item, $withtemplate = 0) {
+
+        switch ($item->getType()) {
+            case 'Preference' :
+                return __('Accessibility');
+
+            case 'User' :
+                if (User::canUpdate()
+                    && $item->currentUserHaveMoreRightThan($item->getID())) {
+                    return __('Accessibility');
+                }
+                break;
+            case Impact::getType():
+                return Impact::getTypeName();
+        }
+        return '';
+    }
+
+    static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0) {
+        global $CFG_GLPI;
+
+        if ($item->getType() == 'Preference') {
+            $config = new self();
+            $user   = new User();
+            if ($user->getFromDB(Session::getLoginUserID())) {
+                $user->computePreferences();
+                $config->showAccessForm($user->fields);
+            }
+
+        } else if ($item->getType() == 'User') {
+            $config = new self();
+            $item->computePreferences();
+            $config->showAccessForm($item->fields);
+        }
+        return true;
+    }
+
+    /*************************************** FORM ********************************************/
+
+    function showAccessForm($data = []) {
+        global $CFG_GLPI, $DB;
+
+        $oncentral = (Session::getCurrentInterface() == "central");
+        $userpref  = false;
+        $url       = Toolbox::getItemTypeFormURL(__CLASS__);
+        $rand      = mt_rand();
+
+        $canedit = Config::canUpdate();
+        $canedituser = Session::haveRight('accessibility', UPDATE);
+        if (array_key_exists('last_login', $data)) {
+            $userpref = true;
+            if ($data["id"] === Session::getLoginUserID()) {
+                $url  = $CFG_GLPI['root_doc']."/front/preference.php";
+            } else {
+                $url  = User::getFormURL();
+            }
+        }
+
+        if ((!$userpref && $canedit) || ($userpref && $canedituser)) {
+            echo "<form name='form' action='$url' method='post' data-track-changes='true'>";
+        }
+
+        if ($userpref) {
+            echo "<input type='hidden' name='id' value='".$data['id']."'>";
+        }
+        echo "<div class='center' id='tabsbody'>";
+        echo "<table class='tab_cadre_fixe'>";
+
+        echo "<tr><th colspan='4'>" . __('Interface') . "</th></tr>";
+        echo "<td><label for='access_zoom_level_drop$rand'>" .__('UI Scale') . "</label></td>";
+        $zooms = [
+            100 => '100%',
+            110 => '110%',
+            120 => '120%',
+            130 => '130%',
+            140 => '140%',
+            150 => '150%',
+            160 => '160%',
+            170 => '170%',
+            180 => '180%',
+            190 => '190%',
+            200 => '200%'
+        ];
+        echo "<td>";
+        Dropdown::showFromArray('access_zoom_level', $zooms, ['value' => $data["access_zoom_level"], 'rand' => $rand]);
+        echo "</td></tr>";
+
+        echo "<td><label for='access_font_drop$rand'>" .__('UI Font') . "</label></td>";
+        $fonts = [
+            ""                  => "Default",
+            "OpenDyslexic"      => "Open Dyslexic Regular",
+            "OpenDyslexicAlta"  => "Open Dyslexic Alta",
+            "Tiresias Infofont" => "Tiresias Infofont"
+        ];
+        echo "<td>";
+        Dropdown::showFromArray('access_font', $fonts, ['value' => $data["access_font"], 'rand' => $rand]);
+        echo "</td></tr>";
+
+        if ((!$userpref && $canedit) || ($userpref && $canedituser)) {
+            echo "<tr class='tab_bg_2'>";
+            echo "<td colspan='4' class='center'>";
+            echo "<input type='submit' name='update' class='submit' value=\""._sx('button', 'Save')."\">";
+            echo "</td></tr>";
+        }
+
+        echo "</table></div>";
+        Html::closeForm();
+    }
+}

--- a/inc/accessibility.class.php
+++ b/inc/accessibility.class.php
@@ -1,3 +1,34 @@
+/**
+ * ---------------------------------------------------------------------
+ * ITSM-NG
+ * Copyright (C) 2022 ITSM-NG and contributors.
+ *
+ * https://www.itsm-ng.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of ITSM-NG.
+ *
+ * ITSM-NG is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * ITSM-NG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with ITSM-NG. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
 <?php
 
 class Accessibility extends CommonDBTM {

--- a/inc/accessibility.class.php
+++ b/inc/accessibility.class.php
@@ -86,6 +86,45 @@ class Accessibility extends CommonDBTM {
 
     /*************************************** FORM ********************************************/
 
+    static function editTabShortcutForm(string $tab) {
+        global $CFG_GLPI, $DB;
+
+        $user = new User();
+        $user->getFromDB(Session::getLoginUserID());
+        $data = $user->fields;
+
+        $split = explode("$", $tab);
+
+        $url       = Toolbox::getItemTypeFormURL(__CLASS__);
+        $rand      = mt_rand();
+
+        $canedit = Config::canUpdate();
+        $canedituser = Session::haveRight('accessibility', UPDATE);
+
+        $form = "<form name='form' action='".$CFG_GLPI['root_doc']."/front/preference.php' method='post' data-track-changes='true'>";
+
+        $form .= "<div class='center' id='tabsbody'>";
+        $form .= "<table class='tab_cadre_fixe'>";
+
+        $form .= "<tr><th colspan='4' style='text-align: center'>" . __('Edit shortcut') . "</th></tr>";
+        $form .= "<td><label for='$rand' style='text-align: center'>" . $split[1] . "</label></td>";
+        $form .= "<td>";
+        $form .= "<textarea></textarea>";
+        $form .= "</td></tr>";
+
+        if (Session::haveRight("accessibility", 2)) {
+            $form .= "<tr class='tab_bg_2'>";
+            $form .= "<td colspan='4' class='center'>";
+            $form .= "<input type='submit' name='update' class='submit' value='"._sx('button', 'Save')."'>";
+            $form .= "</td></tr>";
+        }
+
+        $form .= "</table></div>";
+        $form .= str_replace('"', "'", Html::closeForm(false));
+
+        return $form;
+    }
+
     function showAccessForm($data = []) {
         global $CFG_GLPI, $DB;
 

--- a/inc/accessibility.class.php
+++ b/inc/accessibility.class.php
@@ -113,6 +113,11 @@ class Accessibility extends CommonDBTM {
         Dropdown::showFromArray('access_font', $fonts, ['value' => $data["access_font"], 'rand' => $rand]);
         echo "</td></tr>";
 
+        echo "<td><label for='access_shortcuts_drop$rand'>" .__('Enable shortcuts') . "</label></td>";
+        echo "<td>";
+        Dropdown::showYesNo('access_shortcuts', $data["access_shortcuts"], -1,['rand' => $rand]);
+        echo "</td></tr>";
+
         if ((!$userpref && $canedit) || ($userpref && $canedituser)) {
             echo "<tr class='tab_bg_2'>";
             echo "<td colspan='4' class='center'>";

--- a/inc/ajax.class.php
+++ b/inc/ajax.class.php
@@ -404,11 +404,12 @@ class Ajax {
             $currentShortcut = null;
             echo $title."</a>";
             // Below is code dedicated to rendering the keyboard shortcuts, you shouldn't have to touch this.
-            if(count($val["shortcut"][0])) {
+            if($val["shortcut"] && !is_array($val["shortcut"][1])) {
                 $currentShortcut = $val['shortcut'];
             } else if (!empty($val["shortcut"])) {
                 $currentShortcut = $val['shortcut'][explode("$", $key)[1]];
             }
+
             if ($currentShortcut && $displayShortcuts && $orientation == 'vertical' && count($tabs) > 1) {
                 // I wish doing this wasn't necessary, but it is
                 $shortcutWrapperID = "acc".mt_rand();

--- a/inc/ajax.class.php
+++ b/inc/ajax.class.php
@@ -404,13 +404,10 @@ class Ajax {
             $currentShortcut = null;
             echo $title."</a>";
             // Below is code dedicated to rendering the keyboard shortcuts, you shouldn't have to touch this.
-            if($val["shortcut"] && !is_array($val["shortcut"][1])) {
-                $currentShortcut = $val['shortcut'];
-            } else if (!empty($val["shortcut"])) {
-                $currentShortcut = $val['shortcut'][explode("$", $key)[1]];
-            }
-
-            if ($currentShortcut && $displayShortcuts && $orientation == 'vertical' && count($tabs) > 1) {
+             if ($displayShortcuts && $orientation == 'vertical' && count($tabs) > 1) {
+                 $currentShortcut = json_decode($user->fields["access_custom_shortcuts"], true)[$key];
+             }
+             if (is_array($currentShortcut)) {
                 // I wish doing this wasn't necessary, but it is
                 $shortcutWrapperID = "acc".mt_rand();
                 echo "<div id='$shortcutWrapperID' style='align-items: end;float: right; top: -25px; right: 5%; position: inherit; margin-bottom: -55px; pointer-events: none;'>";

--- a/inc/ajax.class.php
+++ b/inc/ajax.class.php
@@ -367,8 +367,12 @@ class Ajax {
    ) {
       global $CFG_GLPI;
 
+      $user = new User();
+      $user->getFromDB(Session::getLoginUserID());
+
       // TODO need to clean params !!
       $active_tabs = Session::getActiveTab($type);
+      $displayShortcuts = (Session::haveRight("accessibility", READ) && $user->fields["access_shortcuts"]);
 
       $mainclass = '';
       if (isset($options['main_class'])) {
@@ -397,7 +401,29 @@ class Ajax {
             // $limit = 16;
             // No title strip for horizontal menu
             $title = $val['title'];
-            echo $title."</a></li>";
+            $currentShortcut = null;
+            echo $title."</a>";
+            // Below is code dedicated to rendering the keyboard shortcuts, you shouldn't have to touch this.
+            if(count($val["shortcut"][0])) {
+                $currentShortcut = $val['shortcut'];
+            } else if (!empty($val["shortcut"])) {
+                $currentShortcut = $val['shortcut'][explode("$", $key)[1]];
+            }
+            if ($currentShortcut && $displayShortcuts) {
+                // I wish doing this wasn't necessary, but it is
+                $shortcutWrapperID = "acc".mt_rand();
+                echo "<div id='$shortcutWrapperID' style='align-items: end;float: right; top: -25px; right: 5%; position: inherit; margin-bottom: -55px; pointer-events: none;'>";
+                // Generate <kbd> elements
+                echo "<kbd>".implode("</kbd>+<kbd>", $currentShortcut)."</kbd>";
+                echo Html::scriptBlock("
+                    hotkeys('".strtolower(implode("+", $currentShortcut))."', function(e, h) {
+                       e.preventDefault();                        
+                       $('#".$shortcutWrapperID."').prev('a').trigger('click');
+                    });
+                ");
+                echo "</div>";
+            }
+            echo "</li>";
             $current ++;
          }
          echo "</ul>";

--- a/inc/ajax.class.php
+++ b/inc/ajax.class.php
@@ -409,7 +409,7 @@ class Ajax {
             } else if (!empty($val["shortcut"])) {
                 $currentShortcut = $val['shortcut'][explode("$", $key)[1]];
             }
-            if ($currentShortcut && $displayShortcuts) {
+            if ($currentShortcut && $displayShortcuts && $orientation == 'vertical' && count($tabs) > 1) {
                 // I wish doing this wasn't necessary, but it is
                 $shortcutWrapperID = "acc".mt_rand();
                 echo "<div id='$shortcutWrapperID' style='align-items: end;float: right; top: -25px; right: 5%; position: inherit; margin-bottom: -55px; pointer-events: none;'>";

--- a/inc/commonglpi.class.php
+++ b/inc/commonglpi.class.php
@@ -557,6 +557,21 @@ class CommonGLPI {
       return '';
    }
 
+   /**
+    * Returns an array of keyboard keys.
+    *
+    * @param CommonGLPI $item         Item that the shortcut is attached to
+    * @param bool       $withtemplate Is a template object? (default 0)
+    *
+    * @see Item_Ticket::getShortcutsForItem() for a single shortcut implementation
+    * @see Ticket::getShortcutsForItem()      for a multi-shortcut implementation
+    *
+    * @return array Keys for the shortcut
+    */
+   function getShortcutsForItem() {
+       return [];
+   }
+
 
    /**
     * show Tab content
@@ -868,20 +883,32 @@ class CommonGLPI {
          $tabs    = [];
 
          foreach ($onglets as $key => $val) {
-            $tabs[$key] = ['title'  => $val,
-                                'url'    => $tabpage,
-                                'params' => "_target=$target&amp;_itemtype=".$this->getType().
-                                            "&amp;_glpi_tab=$key&amp;id=$ID$extraparamhtml"];
+            if($item = getItemForItemtype(explode("$", $key)[0])) {
+                $shortcut = $item->getShortcutsForItem();
+                if(!count($shortcut)) {
+                    $shortcut = false;
+                }
+            }
+            $tabs[$key] = [
+                'title'    => $val,
+                'shortcut' => $shortcut,
+                'url'      => $tabpage,
+                'params'   => "_target=$target&amp;_itemtype=".$this->getType().
+                              "&amp;_glpi_tab=$key&amp;id=$ID$extraparamhtml"
+            ];
          }
 
          // Not all tab for templates and if only 1 tab
          if ($display_all
              && empty($withtemplate)
              && (count($tabs) > 1)) {
-            $tabs[-1] = ['title'  => __('All'),
-                              'url'    => $tabpage,
-                              'params' => "_target=$target&amp;_itemtype=".$this->getType().
-                                          "&amp;_glpi_tab=-1&amp;id=$ID$extraparamhtml"];
+            $tabs[-1] = [
+                'title'    => __('All'),
+                'shortcut' => false,
+                'url'      => $tabpage,
+                'params'   => "_target=$target&amp;_itemtype=".$this->getType().
+                              "&amp;_glpi_tab=-1&amp;id=$ID$extraparamhtml"
+            ];
          }
 
          Ajax::createTabs('tabspanel', 'tabcontent', $tabs, $this->getType(), $ID,

--- a/inc/commonglpi.class.php
+++ b/inc/commonglpi.class.php
@@ -877,11 +877,6 @@ class CommonGLPI {
       }
 
       if (count($onglets)) {
-         if (count($onglets) > 1 && !CommonGLPI::isLayoutExcludedPage()) {
-             echo "<div style='position: absolute; width: 100%; height: 100%; top: 81px; right: 2px;'>";
-             echo "<button id='shortcut-floater' onclick='alert(\"".$this->getTypeName()."\")'>" . __("Edit shortcut") . "</button>";
-             echo "</div>";
-         }
          $tabpage = $this->getTabsURL();
          $tabs    = [];
 

--- a/inc/commonglpi.class.php
+++ b/inc/commonglpi.class.php
@@ -600,8 +600,7 @@ class CommonGLPI {
     * @return boolean true
    **/
    static function displayStandardTab(CommonGLPI $item, $tab, $withtemplate = 0, $options = []) {
-
-      switch ($tab) {
+       switch ($tab) {
          // All tab
          case -1 :
             // get tabs and loop over
@@ -611,7 +610,6 @@ class CommonGLPI {
                //on classical and vertical split; the main tab is always displayed
                array_shift($ong);
             }
-
             if (count($ong)) {
                foreach ($ong as $key => $val) {
                   if ($key != 'empty') {
@@ -879,6 +877,11 @@ class CommonGLPI {
       }
 
       if (count($onglets)) {
+         if (count($onglets) > 1 && !CommonGLPI::isLayoutExcludedPage()) {
+             echo "<div style='position: absolute; width: 100%; height: 100%; top: 81px; right: 2px;'>";
+             echo "<button id='shortcut-floater' onclick='alert(\"".$this->getTypeName()."\")'>" . __("Edit shortcut") . "</button>";
+             echo "</div>";
+         }
          $tabpage = $this->getTabsURL();
          $tabs    = [];
 

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -6622,9 +6622,15 @@ abstract class CommonITILObject extends CommonDBTM {
     * @return void
     */
    function filterTimeline() {
+      $user = new User();
+      $user->getFromDB(Session::getLoginUserID());
 
+      $font = "Bitstream Vera Sans";
+      if (Session::haveRight("accessibility", READ)) {
+          $font = $user->fields["access_font"];
+      }
       echo "<div class='filter_timeline'>";
-      echo "<h3>".__("Timeline filter")." : </h3>";
+      echo "<h3 style='font-family: $font;'>".__("Timeline filter")." : </h3>";
       echo "<ul>";
 
       $objType = static::getType();
@@ -6658,8 +6664,13 @@ abstract class CommonITILObject extends CommonDBTM {
     * @return void
     */
    function showTimelineHeader() {
-
-      echo "<h2>".__("Actions historical")." : </h2>";
+      $user = new User();
+      $user->getFromDB(Session::getLoginUserID());
+      $font = "Bitstream Vera Sans";
+      if (Session::haveRight("accessibility", READ)) {
+          $font = $user->fields["access_font"];
+      }
+      echo "<h2 style='font-family: $font;'>".__("Actions historical")." : </h2>";
       $this->filterTimeline();
    }
 
@@ -6792,12 +6803,16 @@ abstract class CommonITILObject extends CommonDBTM {
       $user->getFromDB(Session::getLoginUserID());
 
       $canuse_shortcuts = $user->fields['access_shortcuts'];
+      $font = "Bitstream Vera Sans";
+      if (Session::haveRight("accessibility", READ)) {
+          $font = $user->fields["access_font"];
+      }
 
       if ($canadd_fup || $canadd_task || $canadd_document || $canadd_solution) {
-         echo "<h2>"._sx('button', 'Add')." : </h2>";
+         echo "<h2 style='font-family: $font;'>"._sx('button', 'Add')." : </h2>";
       }
       if ($canadd_fup) {
-         echo "<li class='followup' onclick='".
+         echo "<li class='followup' style='font-family: $font;' onclick='".
               "javascript:viewAddSubitem".$this->fields['id']."$rand(\"ITILFollowup\");'>"
               . "<i class='far fa-comment'></i>"._n('Followup', 'Followups', 1);
          echo "</li>";
@@ -6810,7 +6825,7 @@ abstract class CommonITILObject extends CommonDBTM {
          }
       }
       if ($canadd_task) {
-         echo "<li class='task' onclick='".
+         echo "<li class='task' style='font-family: $font;' onclick='".
               "javascript:viewAddSubitem".$this->fields['id']."$rand(\"$taskClass\");'>"
               ."<i class='far fa-check-square'></i>"._n('Task', 'Tasks', 1)."</li>";
          if ($canuse_shortcuts) {
@@ -6822,7 +6837,7 @@ abstract class CommonITILObject extends CommonDBTM {
          }
       }
       if ($canadd_document) {
-         echo "<li class='document' onclick='".
+         echo "<li class='document' style='font-family: $font;' onclick='".
               "javascript:viewAddSubitem".$this->fields['id']."$rand(\"Document_Item\");'>"
               ."<i class='fa fa-paperclip'></i>".Document::getTypeName(1)."</li>";
          if ($canuse_shortcuts) {
@@ -6834,7 +6849,7 @@ abstract class CommonITILObject extends CommonDBTM {
          }
       }
       if ($canadd_validation) {
-         echo "<li class='validation' onclick='".
+         echo "<li class='validation' style='font-family: $font;' onclick='".
             "javascript:viewAddSubitem".$this->fields['id']."$rand(\"$validation_class\");'>"
             ."<i class='far fa-thumbs-up'></i>"._n('Approval', 'Approvals', 1)."</li>";
          if ($canuse_shortcuts) {
@@ -6846,7 +6861,7 @@ abstract class CommonITILObject extends CommonDBTM {
          }
       }
       if ($canadd_solution) {
-         echo "<li class='solution' onclick='".
+         echo "<li class='solution' style='font-family: $font;' onclick='".
               "javascript:viewAddSubitem".$this->fields['id']."$rand(\"Solution\");'>"
               ."<i class='fa fa-check'></i>"._n('Solution', 'Solutions', 1)."</li>";
          if ($canuse_shortcuts) {
@@ -6858,7 +6873,7 @@ abstract class CommonITILObject extends CommonDBTM {
          }
       }
       if ($canuse_shortcuts) {
-         echo "<li class='shortcutpop' onclick=\"".
+         echo "<li class='shortcutpop' style='font-family: $font;' onclick=\"".
               "alert('".
               "<kbd>SHIFT</kbd>+<kbd>F</kbd> : Followup <br> ".
               "<kbd>SHIFT</kbd>+<kbd>T</kbd> : Task <br> ".
@@ -6892,7 +6907,7 @@ abstract class CommonITILObject extends CommonDBTM {
             $total_actiontime = $row['actiontime'];
          }
          if ($total_actiontime > 0) {
-            echo "<h3>";
+            echo "<h3 style='font-family: $font;'>";
             $total   = Html::timestampToString($total_actiontime, false);
             $message = sprintf(__('Total duration: %s'),
                                $total);
@@ -6906,7 +6921,7 @@ abstract class CommonITILObject extends CommonDBTM {
             $states = [Planning::INFO => __('Information tasks: %s %%'),
                        Planning::TODO => __('Todo tasks: %s %%'),
                        Planning::DONE => __('Done tasks: %s %% ')];
-            echo "<h3>";
+            echo "<h3 style='font-family: $font;'>";
             foreach ($states as $state => $string) {
                $criteria = [$foreignKey => $this->fields['id'],
                             "state"     => $state];
@@ -7149,6 +7164,14 @@ abstract class CommonITILObject extends CommonDBTM {
       // show title for timeline
       $this->showTimelineHeader();
 
+      $thisUser = new User();
+      $thisUser->getFromDB(Session::getLoginUserID());
+
+      $font = "Bitstream Vera Sans";
+      if (Session::haveRight("accessibility", READ)) {
+         $font = $thisUser->fields["access_font"];
+      }
+
       $timeline_index = 0;
       foreach ($timeline as $item) {
          $options = [ 'parent' => $this,
@@ -7199,7 +7222,7 @@ abstract class CommonITILObject extends CommonDBTM {
             $user_position.= ' middle';
          }
 
-         echo "<div class='h_item $user_position'>";
+         echo "<div style='font-family: $font;' class='h_item $user_position'>";
 
          echo "<div class='h_info'>";
 
@@ -7572,7 +7595,7 @@ abstract class CommonITILObject extends CommonDBTM {
       echo "<div class='break'></div>";
 
       // recall content
-      echo "<div class='h_item middle'>";
+      echo "<div style='font-family: $font;' class='h_item middle'>";
 
       echo "<div class='h_info'>";
       echo "<div class='h_date'><i class='far fa-clock'></i>".Html::convDateTime($this->fields['date'])."</div>";

--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -6788,34 +6788,84 @@ abstract class CommonITILObject extends CommonDBTM {
       echo "<div class='timeline_form'>";
       echo "<ul class='timeline_choices'>";
 
+      $user = new User();
+      $user->getFromDB(Session::getLoginUserID());
+
+      $canuse_shortcuts = $user->fields['access_shortcuts'];
+
       if ($canadd_fup || $canadd_task || $canadd_document || $canadd_solution) {
          echo "<h2>"._sx('button', 'Add')." : </h2>";
       }
       if ($canadd_fup) {
          echo "<li class='followup' onclick='".
               "javascript:viewAddSubitem".$this->fields['id']."$rand(\"ITILFollowup\");'>"
-              . "<i class='far fa-comment'></i>"._n('Followup', 'Followups', 1)."</li>";
+              . "<i class='far fa-comment'></i>"._n('Followup', 'Followups', 1);
+         echo "</li>";
+         if ($canuse_shortcuts) {
+            echo "<script>
+            hotkeys('shift+f', function(e, h) {
+               e.preventDefault();
+               $('.followup').trigger('click');
+            });</script>";
+         }
       }
-
       if ($canadd_task) {
          echo "<li class='task' onclick='".
               "javascript:viewAddSubitem".$this->fields['id']."$rand(\"$taskClass\");'>"
               ."<i class='far fa-check-square'></i>"._n('Task', 'Tasks', 1)."</li>";
+         if ($canuse_shortcuts) {
+            echo "<script>
+            hotkeys('shift+t', function(e, h) {
+               e.preventDefault();
+               $('.task').trigger('click');
+            });</script>";
+         }
       }
       if ($canadd_document) {
          echo "<li class='document' onclick='".
               "javascript:viewAddSubitem".$this->fields['id']."$rand(\"Document_Item\");'>"
               ."<i class='fa fa-paperclip'></i>".Document::getTypeName(1)."</li>";
+         if ($canuse_shortcuts) {
+            echo "<script>
+            hotkeys('shift+d', function(e, h) {
+               e.preventDefault();
+               $('.document').trigger('click');
+            });</script>";
+         }
       }
       if ($canadd_validation) {
          echo "<li class='validation' onclick='".
             "javascript:viewAddSubitem".$this->fields['id']."$rand(\"$validation_class\");'>"
             ."<i class='far fa-thumbs-up'></i>"._n('Approval', 'Approvals', 1)."</li>";
+         if ($canuse_shortcuts) {
+            echo "<script>
+            hotkeys('shift+a', function(e, h) {
+               e.preventDefault();
+               $('.validation').trigger('click');
+            });</script>";
+         }
       }
       if ($canadd_solution) {
          echo "<li class='solution' onclick='".
               "javascript:viewAddSubitem".$this->fields['id']."$rand(\"Solution\");'>"
               ."<i class='fa fa-check'></i>"._n('Solution', 'Solutions', 1)."</li>";
+         if ($canuse_shortcuts) {
+            echo "<script>
+            hotkeys('shift+s', function(e, h) {
+               e.preventDefault();
+               $('.solution').trigger('click');
+            });</script>";
+         }
+      }
+      if ($canuse_shortcuts) {
+         echo "<li class='shortcutpop' onclick=\"".
+              "alert('".
+              "<kbd>SHIFT</kbd>+<kbd>F</kbd> : Followup <br> ".
+              "<kbd>SHIFT</kbd>+<kbd>T</kbd> : Task <br> ".
+              "<kbd>SHIFT</kbd>+<kbd>D</kbd> : Document <br> ".
+              "<kbd>SHIFT</kbd>+<kbd>A</kbd> : Approval <br> ".
+              "<kbd>SHIFT</kbd>+<kbd>S</kbd> : Solution');\">".
+              __('Shortcuts')."</li>";
       }
       Plugin::doHook('timeline_actions', ['item' => $this, 'rand' => $rand]);
 

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -1676,15 +1676,14 @@ JAVASCRIPT;
             $(function() {
                 $("body").css({
                     "zoom": "$factor%",
-                    "font-family": "'" + "$font" + "', Verdana, Tahoma, 'Sans serif'"
+                    "font-family": "'$font', Verdana, Tahoma, 'Sans serif'"
                    });
-                $("ul").css("font-family", "'" + "$font" + "', Verdana, Arial, 'Sans serif'");
-                $("div").css("font-family", "'" + "$font" + "', Verdana, Arial, 'Sans serif'");
-                $("button").css("font-family", "'" + "$font" + "', Verdana, Arial, 'Sans serif'");
-                $(".vsubmit").css("font-family", "'" + "$font" + "', Arial, Helvetica");
-                $("input").css("font-family", "'" + "$font" + "', Verdana, Tahoma, 'Sans serif'");
-                $("#myname").css("font-family", "'" + "$font" + "', Verdana, Tahoma, 'Sans serif'");
-                $("div.timeline_box").children().css("font-family", "'" + "$font" + "', Verdana, Arial, 'Sans serif'");
+                $("div").css("font-family", "'$font', Verdana, Arial, 'Sans serif'");
+                $("button").css("font-family", "'$font', Verdana, Arial, 'Sans serif'");
+                $(".vsubmit").css("font-family", "'$font', Arial, Helvetica");
+                $("input").css("font-family", "'$font', Verdana, Tahoma, 'Sans serif'");
+                $("#myname").css("font-family", "'$font', Verdana, Tahoma, 'Sans serif'");
+                $("div.timeline_box").children().css("font-family", "'$font', Verdana, Arial, 'Sans serif'");
             })
 JAVASCRIPT
             );

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -1679,6 +1679,7 @@ JAVASCRIPT;
                     "font-family": "'$font', Verdana, Tahoma, 'Sans serif'"
                    });
                 $("div").css("font-family", "'$font', Verdana, Arial, 'Sans serif'");
+                $(".secondary").css("font-family", "'$font', Arial, Helvetica");
                 $("button").css("font-family", "'$font', Verdana, Arial, 'Sans serif'");
                 $(".vsubmit").css("font-family", "'$font', Arial, Helvetica");
                 $("input").css("font-family", "'$font', Verdana, Tahoma, 'Sans serif'");

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -1457,6 +1457,8 @@ JAVASCRIPT;
          }
       }
 
+      self::accessibilityHeader();
+
       // layout
       if (CommonGLPI::isLayoutWithMain()
           && !CommonGLPI::isLayoutExcludedPage()) {
@@ -1650,6 +1652,43 @@ JAVASCRIPT;
       return $menu;
    }
 
+    static function accessibilityHeader() {
+        $user = new User();
+        $user->getFromDB(Session::getLoginUserID());
+        if (Session::haveRight("accessibility", READ)) {
+            $factor = $user->fields["access_zoom_level"];
+            $font = $user->fields["access_font"];
+            switch ($font) {
+                case "OpenDyslexic":
+                    echo '<link href="http://fonts.cdnfonts.com/css/opendyslexic" rel="stylesheet">';     // Use CDNFonts for webfont delivery
+                    break;
+                case "OpenDyslexicAlta":
+                    echo '<link href="http://fonts.cdnfonts.com/css/opendyslexic?styles=29221" rel="stylesheet">';
+                    break;
+                case 'Tiresias Infofont':
+                    echo '<link href="http://fonts.cdnfonts.com/css/tiresias-infofont" rel="stylesheet">';
+                    break;
+                default:
+                    break;
+            }
+            echo Html::scriptBlock(<<<JAVASCRIPT
+            $(function() {
+                $("body").css({
+                    "zoom": "$factor%",
+                    "font-family": "'" + "$font" + "', Verdana, Tahoma, 'Sans serif'"
+                   });
+                $("ul").css("font-family", "'" + "$font" + "', Verdana, Arial, 'Sans serif'");
+                $("div").css("font-family", "'" + "$font" + "', Verdana, Arial, 'Sans serif'");
+                $("button").css("font-family", "'" + "$font" + "', Verdana, Arial, 'Sans serif'");
+                $(".vsubmit").css("font-family", "'" + "$font" + "', Arial, Helvetica");
+                $("input").css("font-family", "'" + "$font" + "', Verdana, Tahoma, 'Sans serif'");
+                $("#myname").css("font-family", "'" + "$font" + "', Verdana, Tahoma, 'Sans serif'");
+                $("div.timeline_box").children().css("font-family", "'" + "$font" + "', Verdana, Arial, 'Sans serif'");
+            })
+JAVASCRIPT
+            );
+        }
+    }
 
    /**
     * Print a nice HTML head for every page

--- a/inc/html.class.php
+++ b/inc/html.class.php
@@ -1423,6 +1423,7 @@ class Html {
 
       // AJAX library
       echo Html::script('public/lib/base.js');
+      echo Html::script('js/hotkeys.js');
 
       // Locales
       $locales_domains = ['glpi' => GLPI_VERSION]; // base domain
@@ -4004,7 +4005,18 @@ JS;
          });
       });";
 
+      echo Html::scriptBlock(<<<JAVASCRIPT
+$('#tinymce.mce-content-body').load(function() {
+    $('#tinymce.mce-content-body').css({
+       'zoom': '200%',
+       'font-family': 'OpenDyslexic'
+    });
+})
+JAVASCRIPT
+      );
+
       if ($display) {
+
          echo  Html::scriptBlock($js);
       } else {
          return  Html::scriptBlock($js);
@@ -6614,6 +6626,9 @@ JAVASCRIPT;
             break;
          case 'photoswipe':
             $_SESSION['glpi_js_toload'][$name][] = 'public/lib/photoswipe.js';
+            break;
+         case 'hotkeys':
+            $_SESSION['glpi_js_toload'][$name][] = 'js/hotkeys.js';
             break;
          default:
             $found = false;

--- a/inc/item_ticket.class.php
+++ b/inc/item_ticket.class.php
@@ -530,8 +530,13 @@ class Item_Ticket extends CommonItilObject_Item {
       return '';
    }
 
+   function getShortcutsForItem()
+   {
+       return ["CTRL", "I"]; // CTRL + I
+   }
 
-   static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0) {
+
+    static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0) {
 
       switch ($item->getType()) {
          case 'Ticket' :

--- a/inc/preference.class.php
+++ b/inc/preference.class.php
@@ -51,6 +51,9 @@ class Preference extends CommonGLPI {
       if (Session::haveRightsOr('personalization', [READ, UPDATE])) {
          $this->addStandardTab('Config', $ong, $options);
       }
+      if (Session::haveRightsOr('accessibility', [READ, UPDATE])) {
+          $this->addStandardTab('Accessibility', $ong, $options);
+      }
       $this->addStandardTab('DisplayPreference', $ong, $options);
 
       $ong['no_all_tab'] = true;

--- a/inc/profile.class.php
+++ b/inc/profile.class.php
@@ -118,7 +118,7 @@ class Profile extends CommonDBTM {
                   $ong[6] = __('Tools');
                   $ong[7] = __('Administration');
                   $ong[8] = __('Setup');
-
+                  $ong[9] = __('Accessibility');
                }
                return $ong;
          }
@@ -174,6 +174,10 @@ class Profile extends CommonDBTM {
                } else {
                   $item->showFormSetup();
                }
+               break;
+
+            case 9:
+               $item->showFormAccess();
                break;
          }
       }
@@ -1433,6 +1437,62 @@ class Profile extends CommonDBTM {
    }
 
 
+    /**
+     * Print the accessibility form for a profile
+     *
+     * @param $openform     boolean  open the form (true by default)
+     * @param $closeform    boolean  close the form (true by default)
+     **/
+    function showFormAccess($openform = true, $closeform = true) {
+        if (!self::canView()) {
+            return false;
+        }
+
+        echo "<div class='spaced'>";
+
+        if (($canedit = Session::haveRightsOr(self::$rightname, [CREATE, UPDATE, PURGE]))
+            && $openform) {
+            echo "<form method='post' action='".$this->getFormURL()."' data-track-changes='true'>";
+        }
+
+        $matrix_options = ['canedit'       => $canedit,
+            'default_class' => 'tab_bg_4'];
+
+        $rights = [
+            [
+                'itemtype'  => 'Accessibility',
+                'label'     => __("Edit accessibility"),
+                'field'     => 'accessibility'
+            ],
+            [
+                'itemtype'  => 'Accessibility',
+                'label'     => __("Change font"),
+                'field'     => 'changefont'
+            ],
+            [
+                'itemtype'  => 'Accessibility',
+                'label'     => __("Change zoom"),
+                'field'     => 'changezoom'
+            ]
+        ];
+
+        $matrix_options['title'] = __('Accessibility');
+        $matrix_options['default_class'] = 'tab_bg_2';
+        $this->displayRightsChoiceMatrix($rights, $matrix_options);
+
+        if ($canedit
+            && $closeform) {
+            echo "<div class='center'>";
+            echo "<input type='hidden' name='id' value='".$this->fields['id']."'>";
+            echo "<input type='submit' name='update' value=\""._sx('button', 'Save')."\" class='submit'>";
+            echo "</div>\n";
+            Html::closeForm();
+        }
+
+        echo "<div/>";
+
+        $this->showLegend();
+    }
    /**
     * Print the central form for a profile
     *

--- a/inc/profile.class.php
+++ b/inc/profile.class.php
@@ -1473,6 +1473,11 @@ class Profile extends CommonDBTM {
                 'itemtype'  => 'Accessibility',
                 'label'     => __("Change zoom"),
                 'field'     => 'changezoom'
+            ],
+            [
+                'itemtype'  => 'Accessibility',
+                'label'     => __("Use shortcuts"),
+                'field'     => 'useshortcuts'
             ]
         ];
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -811,9 +811,18 @@ class Ticket extends CommonITILObject {
       return true;
    }
 
+    function getShortcutsForItem()
+    {
+      return [
+          1      => ["SHIFT", "P"],
+          "main" => ["ALT", "T"],
+          4      => ["ALT", "S"]
+      ];
+    }
 
-   function defineTabs($options = []) {
+    function defineTabs($options = []) {
       $ong = [];
+      $shortcut = [];
 
       $this->defineDefaultObjectTabs($ong, $options);
       $this->addStandardTab('TicketValidation', $ong, $options);

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -822,7 +822,6 @@ class Ticket extends CommonITILObject {
 
     function defineTabs($options = []) {
       $ong = [];
-      $shortcut = [];
 
       $this->defineDefaultObjectTabs($ong, $options);
       $this->addStandardTab('TicketValidation', $ong, $options);
@@ -925,7 +924,7 @@ class Ticket extends CommonITILObject {
       }
 
       // automatic recalculate if user changes urgence or technician change impact
-      $canpriority               = Session::haveRight(self::$rightname, self::CHANGEPRIORITY);
+      $canpriority = Session::haveRight(self::$rightname, self::CHANGEPRIORITY);
       if ((isset($input['urgency']) && $input['urgency'] != $this->fields['urgency'])
          || (isset($input['impact']) && $input['impact'] != $this->fields['impact'])
          && ($canpriority && !isset($input['priority']) || !$canpriority)

--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -247,6 +247,7 @@ class User extends CommonDBTM {
       $this->addStandardTab('Profile_User', $ong, $options);
       $this->addStandardTab('Group_User', $ong, $options);
       $this->addStandardTab('Config', $ong, $options);
+      $this->addStandardTab('Accessibility', $ong, $options);
       $this->addStandardTab(__CLASS__, $ong, $options);
       $this->addStandardTab('Ticket', $ong, $options);
       $this->addStandardTab('Item_Problem', $ong, $options);

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -7082,6 +7082,7 @@ CREATE TABLE `glpi_users` (
   `default_dashboard_mini_ticket` varchar(100) DEFAULT NULL,
   `access_zoom_level` smallint(1) DEFAULT 100,
   `access_font` varchar(100) DEFAULT NULL,
+  `access_shortcuts` tinyint(1) DEFAULT 0,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicityloginauth` (`name`, `authtype`, `auths_id`),
   KEY `firstname` (`firstname`),
@@ -8138,6 +8139,7 @@ CREATE TABLE IF NOT EXISTS `glpi_oidc_config` (
         PRIMARY KEY (`id`)
         ) ENGINE=MyISAM  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
+DROP TABLE IF EXISTS `glpi_specialstatuses`;
 CREATE TABLE IF NOT EXISTS `glpi_specialstatuses` (
         `id` int(11) NOT NULL auto_increment,
         `name` varchar(255) DEFAULT NULL,

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -7080,6 +7080,8 @@ CREATE TABLE `glpi_users` (
   `default_dashboard_assets` varchar(100) DEFAULT NULL,
   `default_dashboard_helpdesk` varchar(100) DEFAULT NULL,
   `default_dashboard_mini_ticket` varchar(100) DEFAULT NULL,
+  `access_zoom_level` smallint(1) DEFAULT 100,
+  `access_font` varchar(100) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicityloginauth` (`name`, `authtype`, `auths_id`),
   KEY `firstname` (`firstname`),

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -7083,6 +7083,7 @@ CREATE TABLE `glpi_users` (
   `access_zoom_level` smallint(1) DEFAULT 100,
   `access_font` varchar(100) DEFAULT NULL,
   `access_shortcuts` tinyint(1) DEFAULT 0,
+  `access_custom_shortcuts` JSON DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unicityloginauth` (`name`, `authtype`, `auths_id`),
   KEY `firstname` (`firstname`),

--- a/js/hotkeys.js
+++ b/js/hotkeys.js
@@ -1,0 +1,550 @@
+/*!
+ * hotkeys-js v3.7.3
+ * A simple micro-library for defining and dispatching keyboard shortcuts. It has no dependencies.
+ *
+ * Copyright (c) 2019 kenny wong <wowohoo@qq.com>
+ * http://jaywcjlove.github.io/hotkeys
+ *
+ * Licensed under the MIT license.
+ */
+
+(function (global, factory) {
+   typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+      typeof define === 'function' && define.amd ? define(factory) :
+         (global = global || self, global.hotkeys = factory());
+}(this, (function () { 'use strict';
+
+   function _typeof(obj) {
+      if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") {
+         _typeof = function (obj) {
+            return typeof obj;
+         };
+      } else {
+         _typeof = function (obj) {
+            return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
+         };
+      }
+
+      return _typeof(obj);
+   }
+
+   var isff = typeof navigator !== 'undefined' ? navigator.userAgent.toLowerCase().indexOf('firefox') > 0 : false; // 绑定事件
+
+   function addEvent(object, event, method) {
+      if (object.addEventListener) {
+         object.addEventListener(event, method, false);
+      } else if (object.attachEvent) {
+         object.attachEvent("on".concat(event), function () {
+            method(window.event);
+         });
+      }
+   } // 修饰键转换成对应的键码
+
+
+   function getMods(modifier, key) {
+      var mods = key.slice(0, key.length - 1);
+
+      for (var i = 0; i < mods.length; i++) {
+         mods[i] = modifier[mods[i].toLowerCase()];
+      }
+
+      return mods;
+   } // 处理传的key字符串转换成数组
+
+
+   function getKeys(key) {
+      if (typeof key !== 'string') key = '';
+      key = key.replace(/\s/g, ''); // 匹配任何空白字符,包括空格、制表符、换页符等等
+
+      var keys = key.split(','); // 同时设置多个快捷键，以','分割
+
+      var index = keys.lastIndexOf(''); // 快捷键可能包含','，需特殊处理
+
+      for (; index >= 0;) {
+         keys[index - 1] += ',';
+         keys.splice(index, 1);
+         index = keys.lastIndexOf('');
+      }
+
+      return keys;
+   } // 比较修饰键的数组
+
+
+   function compareArray(a1, a2) {
+      var arr1 = a1.length >= a2.length ? a1 : a2;
+      var arr2 = a1.length >= a2.length ? a2 : a1;
+      var isIndex = true;
+
+      for (var i = 0; i < arr1.length; i++) {
+         if (arr2.indexOf(arr1[i]) === -1) isIndex = false;
+      }
+
+      return isIndex;
+   }
+
+   var _keyMap = {
+      backspace: 8,
+      tab: 9,
+      clear: 12,
+      enter: 13,
+      "return": 13,
+      esc: 27,
+      escape: 27,
+      space: 32,
+      left: 37,
+      up: 38,
+      right: 39,
+      down: 40,
+      del: 46,
+      "delete": 46,
+      ins: 45,
+      insert: 45,
+      home: 36,
+      end: 35,
+      pageup: 33,
+      pagedown: 34,
+      capslock: 20,
+      '⇪': 20,
+      ',': 188,
+      '.': 190,
+      '/': 191,
+      '`': 192,
+      '-': isff ? 173 : 189,
+      '=': isff ? 61 : 187,
+      ';': isff ? 59 : 186,
+      '\'': 222,
+      '[': 219,
+      ']': 221,
+      '\\': 220
+   }; // Modifier Keys
+
+   var _modifier = {
+      // shiftKey
+      '⇧': 16,
+      shift: 16,
+      // altKey
+      '⌥': 18,
+      alt: 18,
+      option: 18,
+      // ctrlKey
+      '⌃': 17,
+      ctrl: 17,
+      control: 17,
+      // metaKey
+      '⌘': 91,
+      cmd: 91,
+      command: 91
+   };
+   var modifierMap = {
+      16: 'shiftKey',
+      18: 'altKey',
+      17: 'ctrlKey',
+      91: 'metaKey',
+      shiftKey: 16,
+      ctrlKey: 17,
+      altKey: 18,
+      metaKey: 91
+   };
+   var _mods = {
+      16: false,
+      18: false,
+      17: false,
+      91: false
+   };
+   var _handlers = {}; // F1~F12 special key
+
+   for (var k = 1; k < 20; k++) {
+      _keyMap["f".concat(k)] = 111 + k;
+   }
+
+   var _downKeys = []; // 记录摁下的绑定键
+
+   var _scope = 'all'; // 默认热键范围
+
+   var elementHasBindEvent = []; // 已绑定事件的节点记录
+   // 返回键码
+
+   var code = function code(x) {
+      return _keyMap[x.toLowerCase()] || _modifier[x.toLowerCase()] || x.toUpperCase().charCodeAt(0);
+   }; // 设置获取当前范围（默认为'所有'）
+
+
+   function setScope(scope) {
+      _scope = scope || 'all';
+   } // 获取当前范围
+
+
+   function getScope() {
+      return _scope || 'all';
+   } // 获取摁下绑定键的键值
+
+
+   function getPressedKeyCodes() {
+      return _downKeys.slice(0);
+   } // 表单控件控件判断 返回 Boolean
+   // hotkey is effective only when filter return true
+
+
+   function filter(event) {
+      var target = event.target || event.srcElement;
+      var tagName = target.tagName;
+      var flag = true; // ignore: isContentEditable === 'true', <input> and <textarea> when readOnly state is false, <select>
+
+      if (target.isContentEditable || (tagName === 'INPUT' || tagName === 'TEXTAREA') && !target.readOnly) {
+         flag = false;
+      }
+
+      return flag;
+   } // 判断摁下的键是否为某个键，返回true或者false
+
+
+   function isPressed(keyCode) {
+      if (typeof keyCode === 'string') {
+         keyCode = code(keyCode); // 转换成键码
+      }
+
+      return _downKeys.indexOf(keyCode) !== -1;
+   } // 循环删除handlers中的所有 scope(范围)
+
+
+   function deleteScope(scope, newScope) {
+      var handlers;
+      var i; // 没有指定scope，获取scope
+
+      if (!scope) scope = getScope();
+
+      for (var key in _handlers) {
+         if (Object.prototype.hasOwnProperty.call(_handlers, key)) {
+            handlers = _handlers[key];
+
+            for (i = 0; i < handlers.length;) {
+               if (handlers[i].scope === scope) handlers.splice(i, 1);else i++;
+            }
+         }
+      } // 如果scope被删除，将scope重置为all
+
+
+      if (getScope() === scope) setScope(newScope || 'all');
+   } // 清除修饰键
+
+
+   function clearModifier(event) {
+      var key = event.keyCode || event.which || event.charCode;
+
+      var i = _downKeys.indexOf(key); // 从列表中清除按压过的键
+
+
+      if (i >= 0) {
+         _downKeys.splice(i, 1);
+      } // 特殊处理 cmmand 键，在 cmmand 组合快捷键 keyup 只执行一次的问题
+
+
+      if (event.key && event.key.toLowerCase() === 'meta') {
+         _downKeys.splice(0, _downKeys.length);
+      } // 修饰键 shiftKey altKey ctrlKey (command||metaKey) 清除
+
+
+      if (key === 93 || key === 224) key = 91;
+
+      if (key in _mods) {
+         _mods[key] = false; // 将修饰键重置为false
+
+         for (var k in _modifier) {
+            if (_modifier[k] === key) hotkeys[k] = false;
+         }
+      }
+   }
+
+   function unbind(keysInfo) {
+      // unbind(), unbind all keys
+      if (!keysInfo) {
+         Object.keys(_handlers).forEach(function (key) {
+            return delete _handlers[key];
+         });
+      } else if (Array.isArray(keysInfo)) {
+         // support like : unbind([{key: 'ctrl+a', scope: 's1'}, {key: 'ctrl-a', scope: 's2', splitKey: '-'}])
+         keysInfo.forEach(function (info) {
+            if (info.key) eachUnbind(info);
+         });
+      } else if (_typeof(keysInfo) === 'object') {
+         // support like unbind({key: 'ctrl+a, ctrl+b', scope:'abc'})
+         if (keysInfo.key) eachUnbind(keysInfo);
+      } else if (typeof keysInfo === 'string') {
+         for (var _len = arguments.length, args = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+            args[_key - 1] = arguments[_key];
+         }
+
+         // support old method
+         // eslint-disable-line
+         var scope = args[0],
+            method = args[1];
+
+         if (typeof scope === 'function') {
+            method = scope;
+            scope = '';
+         }
+
+         eachUnbind({
+            key: keysInfo,
+            scope: scope,
+            method: method,
+            splitKey: '+'
+         });
+      }
+   } // 解除绑定某个范围的快捷键
+
+
+   var eachUnbind = function eachUnbind(_ref) {
+      var key = _ref.key,
+         scope = _ref.scope,
+         method = _ref.method,
+         _ref$splitKey = _ref.splitKey,
+         splitKey = _ref$splitKey === void 0 ? '+' : _ref$splitKey;
+      var multipleKeys = getKeys(key);
+      multipleKeys.forEach(function (originKey) {
+         var unbindKeys = originKey.split(splitKey);
+         var len = unbindKeys.length;
+         var lastKey = unbindKeys[len - 1];
+         var keyCode = lastKey === '*' ? '*' : code(lastKey);
+         if (!_handlers[keyCode]) return; // 判断是否传入范围，没有就获取范围
+
+         if (!scope) scope = getScope();
+         var mods = len > 1 ? getMods(_modifier, unbindKeys) : [];
+         _handlers[keyCode] = _handlers[keyCode].map(function (record) {
+            // 通过函数判断，是否解除绑定，函数相等直接返回
+            var isMatchingMethod = method ? record.method === method : true;
+
+            if (isMatchingMethod && record.scope === scope && compareArray(record.mods, mods)) {
+               return {};
+            }
+
+            return record;
+         });
+      });
+   }; // 对监听对应快捷键的回调函数进行处理
+
+
+   function eventHandler(event, handler, scope) {
+      var modifiersMatch; // 看它是否在当前范围
+
+      if (handler.scope === scope || handler.scope === 'all') {
+         // 检查是否匹配修饰符（如果有返回true）
+         modifiersMatch = handler.mods.length > 0;
+
+         for (var y in _mods) {
+            if (Object.prototype.hasOwnProperty.call(_mods, y)) {
+               if (!_mods[y] && handler.mods.indexOf(+y) > -1 || _mods[y] && handler.mods.indexOf(+y) === -1) {
+                  modifiersMatch = false;
+               }
+            }
+         } // 调用处理程序，如果是修饰键不做处理
+
+
+         if (handler.mods.length === 0 && !_mods[16] && !_mods[18] && !_mods[17] && !_mods[91] || modifiersMatch || handler.shortcut === '*') {
+            if (handler.method(event, handler) === false) {
+               if (event.preventDefault) event.preventDefault();else event.returnValue = false;
+               if (event.stopPropagation) event.stopPropagation();
+               if (event.cancelBubble) event.cancelBubble = true;
+            }
+         }
+      }
+   } // 处理keydown事件
+
+
+   function dispatch(event) {
+      var asterisk = _handlers['*'];
+      var key = event.keyCode || event.which || event.charCode; // 表单控件过滤 默认表单控件不触发快捷键
+
+      if (!hotkeys.filter.call(this, event)) return; // Gecko(Firefox)的command键值224，在Webkit(Chrome)中保持一致
+      // Webkit左右 command 键值不一样
+
+      if (key === 93 || key === 224) key = 91;
+      /**
+       * Collect bound keys
+       * If an Input Method Editor is processing key input and the event is keydown, return 229.
+       * https://stackoverflow.com/questions/25043934/is-it-ok-to-ignore-keydown-events-with-keycode-229
+       * http://lists.w3.org/Archives/Public/www-dom/2010JulSep/att-0182/keyCode-spec.html
+       */
+
+      if (_downKeys.indexOf(key) === -1 && key !== 229) _downKeys.push(key);
+      /**
+       * Jest test cases are required.
+       * ===============================
+       */
+
+      ['ctrlKey', 'altKey', 'shiftKey', 'metaKey'].forEach(function (keyName) {
+         var keyNum = modifierMap[keyName];
+
+         if (event[keyName] && _downKeys.indexOf(keyNum) === -1) {
+            _downKeys.push(keyNum);
+         } else if (!event[keyName] && _downKeys.indexOf(keyNum) > -1) {
+            _downKeys.splice(_downKeys.indexOf(keyNum), 1);
+         }
+      });
+      /**
+       * -------------------------------
+       */
+
+      if (key in _mods) {
+         _mods[key] = true; // 将特殊字符的key注册到 hotkeys 上
+
+         for (var k in _modifier) {
+            if (_modifier[k] === key) hotkeys[k] = true;
+         }
+
+         if (!asterisk) return;
+      } // 将 modifierMap 里面的修饰键绑定到 event 中
+
+
+      for (var e in _mods) {
+         if (Object.prototype.hasOwnProperty.call(_mods, e)) {
+            _mods[e] = event[modifierMap[e]];
+         }
+      } // 获取范围 默认为 `all`
+
+
+      var scope = getScope(); // 对任何快捷键都需要做的处理
+
+      if (asterisk) {
+         for (var i = 0; i < asterisk.length; i++) {
+            if (asterisk[i].scope === scope && (event.type === 'keydown' && asterisk[i].keydown || event.type === 'keyup' && asterisk[i].keyup)) {
+               eventHandler(event, asterisk[i], scope);
+            }
+         }
+      } // key 不在 _handlers 中返回
+
+
+      if (!(key in _handlers)) return;
+
+      for (var _i = 0; _i < _handlers[key].length; _i++) {
+         if (event.type === 'keydown' && _handlers[key][_i].keydown || event.type === 'keyup' && _handlers[key][_i].keyup) {
+            if (_handlers[key][_i].key) {
+               var record = _handlers[key][_i];
+               var splitKey = record.splitKey;
+               var keyShortcut = record.key.split(splitKey);
+               var _downKeysCurrent = []; // 记录当前按键键值
+
+               for (var a = 0; a < keyShortcut.length; a++) {
+                  _downKeysCurrent.push(code(keyShortcut[a]));
+               }
+
+               if (_downKeysCurrent.sort().join('') === _downKeys.sort().join('')) {
+                  // 找到处理内容
+                  eventHandler(event, record, scope);
+               }
+            }
+         }
+      }
+   } // 判断 element 是否已经绑定事件
+
+
+   function isElementBind(element) {
+      return elementHasBindEvent.indexOf(element) > -1;
+   }
+
+   function hotkeys(key, option, method) {
+      _downKeys = [];
+      var keys = getKeys(key); // 需要处理的快捷键列表
+
+      var mods = [];
+      var scope = 'all'; // scope默认为all，所有范围都有效
+
+      var element = document; // 快捷键事件绑定节点
+
+      var i = 0;
+      var keyup = false;
+      var keydown = true;
+      var splitKey = '+'; // 对为设定范围的判断
+
+      if (method === undefined && typeof option === 'function') {
+         method = option;
+      }
+
+      if (Object.prototype.toString.call(option) === '[object Object]') {
+         if (option.scope) scope = option.scope; // eslint-disable-line
+
+         if (option.element) element = option.element; // eslint-disable-line
+
+         if (option.keyup) keyup = option.keyup; // eslint-disable-line
+
+         if (option.keydown !== undefined) keydown = option.keydown; // eslint-disable-line
+
+         if (typeof option.splitKey === 'string') splitKey = option.splitKey; // eslint-disable-line
+      }
+
+      if (typeof option === 'string') scope = option; // 对于每个快捷键进行处理
+
+      for (; i < keys.length; i++) {
+         key = keys[i].split(splitKey); // 按键列表
+
+         mods = []; // 如果是组合快捷键取得组合快捷键
+
+         if (key.length > 1) mods = getMods(_modifier, key); // 将非修饰键转化为键码
+
+         key = key[key.length - 1];
+         key = key === '*' ? '*' : code(key); // *表示匹配所有快捷键
+         // 判断key是否在_handlers中，不在就赋一个空数组
+
+         if (!(key in _handlers)) _handlers[key] = [];
+
+         _handlers[key].push({
+            keyup: keyup,
+            keydown: keydown,
+            scope: scope,
+            mods: mods,
+            shortcut: keys[i],
+            method: method,
+            key: keys[i],
+            splitKey: splitKey
+         });
+      } // 在全局document上设置快捷键
+
+
+      if (typeof element !== 'undefined' && !isElementBind(element) && window) {
+         elementHasBindEvent.push(element);
+         addEvent(element, 'keydown', function (e) {
+            dispatch(e);
+         });
+         addEvent(window, 'focus', function () {
+            _downKeys = [];
+         });
+         addEvent(element, 'keyup', function (e) {
+            dispatch(e);
+            clearModifier(e);
+         });
+      }
+   }
+
+   var _api = {
+      setScope: setScope,
+      getScope: getScope,
+      deleteScope: deleteScope,
+      getPressedKeyCodes: getPressedKeyCodes,
+      isPressed: isPressed,
+      filter: filter,
+      unbind: unbind
+   };
+
+   for (var a in _api) {
+      if (Object.prototype.hasOwnProperty.call(_api, a)) {
+         hotkeys[a] = _api[a];
+      }
+   }
+
+   if (typeof window !== 'undefined') {
+      var _hotkeys = window.hotkeys;
+
+      hotkeys.noConflict = function (deep) {
+         if (deep && window.hotkeys === hotkeys) {
+            window.hotkeys = _hotkeys;
+         }
+
+         return hotkeys;
+      };
+
+      window.hotkeys = hotkeys;
+   }
+
+   return hotkeys;
+
+})));


### PR DESCRIPTION
# Features

- [x] Change UI Font
- [x] Change UI Zoom (FF unsupported)
- [x] Use Keyboard Shortcuts to Change Tabs
- [ ] Edit shortcuts
- [ ] Sync TinyMCE to Accessibility Settings
- [ ] Automatically Open `Processing Ticket` Tab in Tickets View

# Notes

## Change UI Zoom

FireFox does not implement the zoom css directive.

## Edit shortcuts

Most of the keyboard shortcut editor is done, we just need to add the ability to input shortcuts in the settings form.
See: [accessibility.class.php](https://github.com/Soulusions/itsm-ng/blob/devaccessibility/inc/accessibility.class.php#L194)

## Sync TinyMCE

TinyMCE style is fetched through a `css` file, could not find a proper way to change that file per user, something to look into.

## Open `Processing Ticket` Tab Automatically

Changing the Ajax parameter didn't seem to work, I think I'm missing something.