### PR TITLE
fix import of ldap users

### DIFF
--- a/inc/user.class.php
+++ b/inc/user.class.php
@@ -1596,7 +1596,7 @@ class User extends CommonDBTM {
          return false;
       }
 
-      if (is_resource($ldap_connection)) {
+      if ($ldap_connection !== false) {
          //Set all the search fields
          $this->fields['password'] = "";
 


### PR DESCRIPTION
fix is_resource() returning false with ldap connection object and preventing import of ldap users (php 8.1 change)