### PR TITLE
Bug en mode debug mysqli:init deprecated last PHP (itsm-ng)

### DIFF
--- a/inc/system/requirementslist.class.php
+++ b/inc/system/requirementslist.class.php
@@ -57,7 +57,7 @@ class RequirementsList implements \IteratorAggregate {
       $this->requirements = $requirements;
    }
 
-   public function getIterator() {
+   public function getIterator(): \Traversable{
       return new \ArrayIterator($this->requirements);
    }
 


### PR DESCRIPTION
As of PHP 8.1, fix the return type of the function **getIterator** to match with  interface