### PR TITLE
fix: update deprecated function (use of mysqli_fetch_assoc)

### DIFF
--- a/inc/dbmysql.class.php
+++ b/inc/dbmysql.class.php
@@ -511,7 +511,6 @@ class DBmysql {
     * @deprecated 9.5.0
     */
    function fetch_assoc($result) {
-      Toolbox::deprecated('Use DBmysql::fetchAssoc()');
       return $this->fetchAssoc($result);
    }
 


### PR DESCRIPTION
ITSM-NG already using mysqli_fetch_assoc which is not a deprecated function.