### PR TITLE
fix max shema version

### DIFF
--- a/inc/define.php
+++ b/inc/define.php
@@ -42,7 +42,7 @@ if (substr(GLPI_VERSION, -4) === '-dev') {
    );
 } else {
    //for stable version
-   define("GLPI_SCHEMA_VERSION", '9.5.13');
+   define("GLPI_SCHEMA_VERSION", '9.5.7');
 }
 define('GLPI_MIN_PHP', '7.2.0'); // Must also be changed in top of index.php
 


### PR DESCRIPTION
La dernière version du schema de la base est la 9.5.7 (aucune migration de base depuis)