### PR TITLE
lighten menu

### DIFF
--- a/css/itsm2.scss
+++ b/css/itsm2.scss
@@ -886,10 +886,20 @@ main {
 .menu-bottom {
     position: absolute;
     display: flex;
-    flex-direction: column;
-    justify-content: space-between;
+    flex-direction: row;
+    justify-content: space-around;
     bottom: 0;
     width: 100%;
+}
+
+.icons_nav {
+    color: rgb(255, 255, 255);
+    font-size: 22px;
+}
+
+.icons_nav:hover {
+    color: rgb(255, 255, 255);
+    cursor: pointer;
 }
 
 #c_preference {
@@ -1285,4 +1295,16 @@ div.chip > p {
 
 #data-selection-widget-modal input[name="search"] {
     display: none;
+}
+
+#language_link a i {
+    font-size: 26px;
+}
+
+#menu-options a i {
+    font-size: 21px;
+}
+
+#dropdownMenuButton {
+    font-size: 21px;
 }

--- a/templates/headers/header.twig
+++ b/templates/headers/header.twig
@@ -30,49 +30,55 @@
             </div>
 			{% endif %}
 
-			<ul class='d-flex justify-content-around m-0'>
-				<li id='language_link' class="p-2">
-					<a href="{{root_doc}}/front/preference.php?forcetab=User$1" title={{'Language'|trans}}>
-						<i class='fa fa-globe '></i>
-					</a>
-				</li>
-
-				{% if can_update %}
-					<li id='debug_mode' class='p-2'>
-						<a href='{{root_doc}}/ajax/switchdebug.php' class="debug{{is_debug_active ? 'on' : 'off'}}" title="{{'Change mode'|trans}} {{is_debug_active ? 'Debug mode enabled'|trans : 'Debug mode disabled'|trans}}">
-						    <i class='fa fa-bug'></i>
-							<span class='sr-only'>{{'Change mode'|trans}}</span>
+			<div class="d-flex justify-content-start align-items-center">
+				<ul class="list-unstyled d-flex justify-content-around m-0">
+					<li id="language_link" class="p-2">
+						<a href="{{root_doc}}/front/preference.php?forcetab=User$1" title={{'Language'|trans}}>
+							<i class="fas fa-language"></i>
 						</a>
 					</li>
-				{% endif %}
-				<li id='menu-options' class="dropdown p-2">
-					<a title={{'Options'|trans}} data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-						<i class="fas fa-sort-amount-down"></i>
-					</a>
-                    {% include "nav/nav-settings.twig" %}
-				</li>
-				<li id='menu-options' class="dropdown p-2">
-					<a title={{'Help'|trans}} href="https://www.itsm-ng.org">
-						<i class="fas fa-question"></i>
-					</a>
-				</li>
-				<li id='preferences_link' class='p-2'>
-					<a href='{{root_doc}}/front/preference.php' title="{{'My settings'|trans}} - {{username}}">
-						<i class='fa fa-cog'></i>
-                        <span class='sr-only'>{{'My settings'|trans}}</span>
-						{% if username %}
-							<span id='myname test-info'>{{username}}</span>
+					<li id="menu-options" class="p-2">
+						<a href="#" title={{'Navbar'|trans}} data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+							<i class="far fa-window-maximize"></i>
+						</a>
+						{% include "nav/nav-settings.twig" %}
+					</li>
+				</ul>
+			
+				<div class="dropdown">
+					<button class="btn btn-outline-light" type="button" id="dropdownMenuButton" data-bs-toggle="dropdown" aria-expanded="false">
+						<i class="fas fa-bars"></i>
+					</button>
+					<ul class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+						{% if can_update %}
+						<li id="debug_mode" class="dropdown-item">
+							<a href="{{root_doc}}/ajax/switchdebug.php" class="debug{{is_debug_active ? 'on' : 'off'}}" title="{{'Change mode'|trans}} {{is_debug_active ? 'Debug mode enabled'|trans : 'Debug mode disabled'|trans}}">
+								Debug mode
+							</a>
+						</li>
 						{% endif %}
-					</a>
-				</li>
-
-				<li id='deconnexion' class='p-2'>
-					<a href="{{root_doc}}/front/logout.php{{noAUTO ? '?noAUTO=1'}}" title={{'Logout'|trans}}>
-						<i class='fa fa-sign-out-alt'></i>
-						<span class='sr-only'>{{'Logout'|trans}}></span>
-					</a>
-				</li>
-			</ul>
+						<li id="menu-help" class="dropdown-item">
+							<a href="https://www.itsm-ng.org" title={{'Help'|trans}}>
+								Help
+							</a>
+						</li>
+						<li id="preferences_link" class="dropdown-item">
+							<a href="{{root_doc}}/front/preference.php" title="{{'My settings'|trans}} - {{username}}">
+								Profile
+								{% if username %}
+									<span id="myname test-info">{{username}}</span>
+								{% endif %}
+							</a>
+						</li>
+						<li id="deconnexion" class="dropdown-item">
+							<a href="{{root_doc}}/front/logout.php{{noAUTO ? '?noAUTO=1'}}" title={{'Logout'|trans}}>
+								Logout
+							</a>
+						</li>
+					</ul>
+				</div>
+			</div>
+			
 		</header>
 
 		{% if accessibilityMenu %}
@@ -88,7 +94,12 @@
 				<div id="menu-border" onmousedown="resizeMenu()"></div>
 				{% include main_menu.path with main_menu.args %}
 				<div class="menu-bottom">
-					<a class="copyright-message" href="https://www.itsm-ng.com" target="_blank" title="{{ITSM_VERSION}} Copyright (C) {{ITSM_YEAR}} ITSM-NG and contributors"></a>
+					<a class="icons_nav" href="https://github.com/itsmng" target="_blank">
+						<i class="fab fa-github"></i>
+					</a>
+					<a class ="icons_nav" href="https://www.itsm-ng.com" target="_blank" title="{{ITSM_VERSION}} Copyright (C) {{ITSM_YEAR}} ITSM-NG and contributors">
+						<i class="fas fa-globe"></i>
+					</a>
 				</div>
 			</nav>
 			<div class="main-container">
@@ -100,3 +111,5 @@
 					{% include "headers/utils/actions.twig" with {'links': links, 'root_doc':root_doc} %}
 				</div>
 				<main role='main' id='page'>
+
+					

--- a/templates/nav/menu.twig
+++ b/templates/nav/menu.twig
@@ -5,8 +5,8 @@
         <ul id="menu-content" class="menu-content collapse out">
 
             {% for menu_name, data in menu|filter(data => data['show_menu']) %}
-                <li title="{{data['title']}}" id='menu-{{menu_name}}' class='menu {{data['class']}} {{menu_favorite_on ? '' : 'hidden'}}'>
-                    <a class="{{menu[menu_name]['is_open'] ?: 'collapsed'}}" onclick="openMenu(this, '{{menu_name}}')" data-bs-toggle="collapse" data-bs-target="#submenu-{{menu_name}}">
+                <li title="{{data['title']}}" id='menu-{{menu_name}}' class='menu {{data['class']}} {{menu_favorite_on ? '' : 'hidden'}}' tabindex="0">
+                    <a href="#" class="nav-link {{menu[menu_name]['is_open'] ?: 'collapsed'}}" onclick="openMenu(this, '{{menu_name}}')" data-bs-toggle="collapse" data-bs-target="#submenu-{{menu_name}}" aria-expanded="false">
                         <i class="bubble-icon fas {{menu[menu_name]['icon']}}"></i>
                         <span>{{data['title']}}</span>
                     </a>

--- a/templates/nav/nav-settings.twig
+++ b/templates/nav/nav-settings.twig
@@ -5,10 +5,6 @@
 	<span class="dropdown-item" href="#">{{'Menu collapse'|trans}}
 		:
 		{{input("", "", "checkbox", "form-check-input", "menu-collapse-toggle" ,"", "", "", menu_small ? 'true')}}</span>
-	<span class="dropdown-item" href="#">{{'Reset menu bubble position'|trans}}
-		:
-		<button id"reset-bubble-button" type="button" class="btn btn-primary btn-sm">Reset</button>
-	</span>
 	<hr>
 	<h6 class="dropdown-header">{{'Menu favorite'|trans}}</h6>
 	<span class="dropdown-item" href="#">{{'Activate menu favorite'|trans}}
@@ -24,7 +20,6 @@
 			<option value="menu-left" {{menu_position == 'menu-left' ? 'selected'}}>{{'Left'|trans}}</option>
 			<option value="menu-top" {{menu_position == 'menu-top' ? 'selected'}}>{{'Up'|trans}}</option>
 			<option value="menu-right" {{menu_position == 'menu-right' ? 'selected'}}>{{'Right'|trans}}</option>
-			<option value="menu-bubble" {{menu_position == 'menu-bubble' ? 'selected'}}>{{'Bubble'|trans}}</option>
 		</select>
 	</div>
 </ul>


### PR DESCRIPTION
- Removed bubble menu
- Add a dropdown on top right for lighten the bar
- Change icon for languages and Navbar Options
- Added Github link and modifiy copyright at bottom navbar

Accessibility : 
- You can now tab all over menus and submenus in nav