### PR TITLE
fix: group name parsing on oidc check

### DIFF
--- a/inc/oidc.class.php
+++ b/inc/oidc.class.php
@@ -239,7 +239,7 @@ class Oidc extends CommonDBTM
                $request = $DB->request('glpi_groups');
 
                while ($data = $request->next()) {
-                  if ($data['name'] == $value) {
+                  if ($data['name'] == $value || $data['name'] == stripslashes($value)) {
                      $id_group_create = $data['id'];
                      break;
                   }


### PR DESCRIPTION
Prevent groups from behind recreated if it containes an escapable character