### PR TITLE
fix(templates): fix null check in table.twig template

### DIFF
--- a/templates/table.twig
+++ b/templates/table.twig
@@ -178,14 +178,12 @@
 
 	{% if massive_action is defined %}
 	function VerifyMassiveAction{{rand}}(value, row, index) {
-		if (!row.value && row._data.value) {
-			row.value = row._data.value;
-		}
+		row.value = row._data?.value;
 		if (!row.value) {
 			return {
 				disabled: true
 			}
-		};
+		}
 	}
 	{% endif %}
 </script>


### PR DESCRIPTION
Fix a minor null check, fixes a rare issue where tables would not render.