### PR TITLE
fix(modal): fixed iframe modal having overflow-y hidden

### DIFF
--- a/inc/ajax.class.php
+++ b/inc/ajax.class.php
@@ -341,8 +341,12 @@ class Ajax
                width: " . $param['width'] . ",
                draggable: true,
                resizeable: true,
-               open: function(ev, ui){
-               $('#Iframe$domid').attr('src','$url').removeClass('hidden');},";
+                open: function(ev, ui) {
+                    $('#Iframe$domid').attr('src','$url').removeClass('hidden');
+                    $('#Iframe$domid').on('load', function() {
+                        $(this).contents().find('body').css('overflow-y', 'scroll');
+                    });
+                },";
         if ($param['reloadonclose']) {
             $out .= "close: function(ev, ui) { window.location.reload() },";
         }


### PR DESCRIPTION
Fixed the `Ajax::createIframeModalWindow()` function creating a modal with hidden overflow-y, which prevented scrolling large tables mainly.