### PR TITLE
fix(cartridge): counts not rendering in search table

### DIFF
--- a/inc/cartridge.class.php
+++ b/inc/cartridge.class.php
@@ -383,6 +383,10 @@ class Cartridge extends CommonDBChild
             }
 
 
+            // TODO: currently we basically always use the nohtml parameter
+            //       problem being that the HTML table is rendered directly
+            //       and in our case we want to return a string, so we just 
+            //       use the nohtml option as a fallback.
             if (!$nohtml) {
                 $fields = [
                    __('Total'),

--- a/inc/search.class.php
+++ b/inc/search.class.php
@@ -6527,6 +6527,12 @@ JAVASCRIPT;
                         false
                     );
 
+                case 'glpi_cartridgeitems._virtual':
+                    return Cartridge::getCount(
+                        $data["id"],
+                        $data[$ID][0]['alarm_threshold'],
+                        true);
+
                 case 'glpi_printers._virtual':
                     return Cartridge::getCountForPrinter(
                         $data["id"],


### PR DESCRIPTION
Fixes the "Cartridge" column in the cartridge view not showing counts, currently using a pure text fallback since the twig template can't be rendered properly due to the design of the existing code.