### PR TITLE
fix(tickettask): set ticket task default to todo

### DIFF
--- a/inc/commonitiltask.class.php
+++ b/inc/commonitiltask.class.php
@@ -1707,7 +1707,8 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
                           Planning::INFO => _n('Information', 'Information', 1),
                           Planning::TODO => __('To do'),
                           Planning::DONE => __('Done')
-                       ]
+                       ],
+                       'value' => Planning::TODO,
                     ] : [],
                     __('Private') => ($this->maybePrivate()) ? [
                        'type' => 'checkbox',


### PR DESCRIPTION
Sets the default state of a ticket task to "To do" like in v1, default was "Information".