### PR TITLE
fix(sim): add a rightname to `Item_DeviceSimcard`

### DIFF
--- a/inc/item_devicesimcard.class.php
+++ b/inc/item_devicesimcard.class.php
@@ -45,6 +45,7 @@ class Item_DeviceSimcard extends Item_Devices {
 
    static public $itemtype_2 = 'DeviceSimcard';
    static public $items_id_2 = 'devicesimcards_id';
+   static public $rightname = 'device';
 
    static protected $notable = false;
 


### PR DESCRIPTION
Adds a rightname to `Item_DeviceSimcard`, its absence made exporting the simcard table impossible.