### PR TITLE
fix(dropdown): tooltip styles

### DIFF
--- a/inc/dropdown.class.php
+++ b/inc/dropdown.class.php
@@ -225,7 +225,9 @@ class Dropdown
                     )
                 );
             }
+            $output .= "<span class='input-group-text'>";
             $output .= Html::showToolTip($comment, $options_tooltip);
+            $output .= "</span>";
 
             if (
                 ($item instanceof CommonDropdown)


### PR DESCRIPTION
This fixes dropdown tooltips not being inside a container and rendering as a very narrow "i" with no padding.