### PR TITLE
fix(table): incorrect total row count on server-side tables

### DIFF
--- a/templates/table.twig
+++ b/templates/table.twig
@@ -230,7 +230,7 @@ $(document).ready(function() {
         const totalPages = table.getPageCount();
         const currentPage = table.getState().pagination.pageIndex + 1;
         const pageSize = table.getState().pagination.pageSize;
-        const totalRows = table.getFilteredRowModel().rows.length;
+        const totalRows = url ? serverTotal : table.getFilteredRowModel().rows.length;
         const startRow = table.getState().pagination.pageIndex * pageSize + 1;
         const endRow = Math.min((table.getState().pagination.pageIndex + 1) * pageSize, totalRows);
 


### PR DESCRIPTION
Server-side tables would render the total number of rows as being the number of rows in the current page.