### PR TITLE
feat(forms): file size validation on document upload fields

### DIFF
--- a/inc/commonitiltask.class.php
+++ b/inc/commonitiltask.class.php
@@ -1753,6 +1753,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
                        'type' => 'file',
                        'name' => 'files',
                        'id' => 'fileSelectorForDocument',
+                       'data-max-size' => Document::getMaxUploadSizeInBytes(),
                        'multiple' => true,
                        'values' => getLinkedDocumentsForItem('Ticket', $ID),
                        'col_lg' => 12,

--- a/inc/document.class.php
+++ b/inc/document.class.php
@@ -496,6 +496,7 @@ class Document extends CommonDBTM
                        'type' => 'file',
                        'name' => 'files',
                        'id' => 'fileSelectorForDocument',
+                       'data-max-size' => self::getMaxUploadSizeInBytes(),
                     ],
                  ],
               ],
@@ -549,6 +550,13 @@ class Document extends CommonDBTM
         return sprintf(__('%s Mio max'), round($max_size, 1));
     }
 
+    /**
+     * Get max upload size from config in bytes
+     * @return int
+     */
+    public static function getMaxUploadSizeInBytes() {
+        return Toolbox::return_bytes_from_ini_vars(ini_get('upload_max_filesize'));
+    }
 
     /**
      * Send a document to navigator

--- a/inc/document_item.class.php
+++ b/inc/document_item.class.php
@@ -737,6 +737,7 @@ class Document_Item extends CommonDBRelation
                            'type' => 'file',
                            'name' => 'files',
                            'id' => 'fileSelectorForDocument',
+                           'data-max-size' => Document::getMaxUploadSizeInBytes(),
                            'multiple' => 'multiple',
                            'col_lg' => 6,
                         ],

--- a/inc/itilfollowup.class.php
+++ b/inc/itilfollowup.class.php
@@ -988,6 +988,7 @@ class ITILFollowup extends CommonDBChild
                            'name' => 'files',
                            'id' => 'fileSelectorForDocument',
                            'multiple' => true,
+                           'data-max-size' => Document::getMaxUploadSizeInBytes(),
                            'values' => getLinkedDocumentsForItem('Ticket', $ID),
                            'col_lg' => 12,
                            'col_md' => 12,

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -5220,6 +5220,7 @@ class Ticket extends CommonITILObject
                      'type' => 'file',
                      'name' => 'files',
                      'id' => 'fileSelectorForDocument',
+                     'data-max-size' => Document::getMaxUploadSizeInBytes(),
                      'multiple' => true,
                      'values' => getLinkedDocumentsForItem('Ticket', $ID),
                      'col_lg' => 6,

--- a/templates/macros/inputs/file.twig
+++ b/templates/macros/inputs/file.twig
@@ -33,7 +33,35 @@
     $(`#ObjectTable_{{rand}} tr[data-id='${id}'][data-type='${type}']`).remove();
   }
 
+  function prettyPrintBytes(bytes) {
+    if (bytes === 0) return '0 B';
+    const k = 1024;
+    const sizes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+  }
+
   $('#{{attributes.id|default(rand)}}').on('change', function() {
+    const $input = $(this);
+    const maxSize = parseInt($input.attr('data-max-size'), 10);
+    const files = this.files;
+    let tooBig = false;
+
+    $input.removeClass('is-invalid');
+    $input.next('.invalid-feedback').remove();
+
+    for (let i = 0; i < files.length; i++) {
+      if (files[i].size > maxSize) {
+        tooBig = true;
+        break;
+      }
+    }
+
+    if (tooBig) {
+      $input.addClass('is-invalid');
+      $input.after('<div class="invalid-feedback">{{"The uploaded file exceeds the upload_max_filesize directive in php.ini"|trans}} (' + prettyPrintBytes(maxSize) + ')</div>');
+      $input.val(''); // Clear the input
+    } else {
       let formData = new FormData();
       formData.append('name', 'filename');
       formData.append('showFileSize', $('#{{attributes.id|default(rand)}}').prop('files').length);
@@ -42,18 +70,19 @@
       }
       $.ajax({
       url: '{{root_doc}}' + '/ajax/fileupload.php',
-          type: 'POST',
-          data: formData,
-          processData: false,
-          contentType: false,
-          success: function(data) {
-          // add an hidden input containing the data for all files
-              if ($('#hiddenInputForFiles').length == 0) {
-                  $('#{{attributes.id|default(rand)}}').after('<input type="hidden" id="hiddenInputForFiles{{rand}}" name="{{attributes.name}}" value="">');
-              }
-              $('#hiddenInputForFiles{{rand}}').val(data);
+        type: 'POST',
+        data: formData,
+        processData: false,
+        contentType: false,
+        success: function(data) {
+        // add an hidden input containing the data for all files
+          if ($('#hiddenInputForFiles').length == 0) {
+            $('#{{attributes.id|default(rand)}}').after('<input type="hidden" id="hiddenInputForFiles{{rand}}" name="{{attributes.name}}" value="">');
           }
+          $('#hiddenInputForFiles{{rand}}').val(data);
+        }
       });
+    }
   })
   </script>
 {% endmacro %}


### PR DESCRIPTION
Now when adding files to upload fields we check whether the file is too big to upload or not and display an error if that's the case.