### PR TITLE
fix(plugin): reintroduce `autoinventory_information` hooks

### DIFF
--- a/inc/computer.class.php
+++ b/inc/computer.class.php
@@ -327,6 +327,13 @@ class Computer extends CommonDBTM
      **/
     public function showForm($ID, $options = [])
     {
+        $autoinventory_information = '';
+        if ($ID && $this->fields['is_dynamic']) {
+            ob_start();
+            Plugin::doHook("autoinventory_information", $this);
+            $autoinventory_information = ob_get_clean();
+        }
+
         $form = [
            'action' => $this->getFormURL(),
            'itemtype' => $this::class,
@@ -452,6 +459,8 @@ class Computer extends CommonDBTM
            ]
         ];
         $additionnalHtml = '';
+
+        $additionnalHtml .= $autoinventory_information;
 
         if (isset($this->fields['is_deleted']) && $this->fields['is_deleted'] == 1) {
             if ($this->can($ID, PURGE)) {

--- a/inc/networkequipment.class.php
+++ b/inc/networkequipment.class.php
@@ -284,6 +284,13 @@ class NetworkEquipment extends CommonDBTM
     {
         $title = self::getTypeName(1);
 
+        $autoinventory_information = '';
+        if ($ID && $this->fields['is_dynamic']) {
+            ob_start();
+            Plugin::doHook("autoinventory_information", $this);
+            $autoinventory_information = ob_get_clean();
+        }
+
         $form = [
            'action' => $this->getFormURL(),
            'itemtype' => $this::class,
@@ -402,7 +409,11 @@ class NetworkEquipment extends CommonDBTM
            ]
         ];
 
-        renderTwigForm($form, '', $this->fields);
+        $additionalHtml = '';
+
+        $additionalHtml .= $autoinventory_information;
+
+        renderTwigForm($form, $additionalHtml, $this->fields);
         return true;
     }
 

--- a/inc/peripheral.class.php
+++ b/inc/peripheral.class.php
@@ -166,6 +166,13 @@ class Peripheral extends CommonDBTM
 
         $isNew = $this->isNewID($ID) || (isset($options['withtemplate']) && $options['withtemplate'] == 2);
 
+        $autoinventory_information = '';
+        if ($ID && $this->fields['is_dynamic']) {
+            ob_start();
+            Plugin::doHook("autoinventory_information", $this);
+            $autoinventory_information = ob_get_clean();
+        }
+
         $form = [
            'action' => $this->getFormURL(),
            'itemtype' => $this::class,
@@ -289,7 +296,11 @@ class Peripheral extends CommonDBTM
            ]
         ];
 
-        renderTwigForm($form, '', $this->fields);
+        $additionalHtml = '';
+
+        $additionalHtml .= $autoinventory_information;
+
+        renderTwigForm($form, $additionalHtml, $this->fields);
         return true;
     }
 

--- a/inc/printer.class.php
+++ b/inc/printer.class.php
@@ -286,6 +286,13 @@ class Printer extends CommonDBTM
 
         $isNew = $this->isNewID($ID) || (isset($options['withtemplate']) && $options['withtemplate'] == 2);
 
+        $autoinventory_information = '';
+        if ($ID && $this->fields['is_dynamic']) {
+            ob_start();
+            Plugin::doHook("autoinventory_information", $this);
+            $autoinventory_information = ob_get_clean();
+        }
+
         $form = [
            'action' => $this->getFormURL(),
            'itemtype' => $this::class,
@@ -435,7 +442,11 @@ class Printer extends CommonDBTM
            ]
         ];
 
-        renderTwigForm($form, '', $this->fields);
+        $additionnalHtml = '';
+
+        $additionnalHtml .= $autoinventory_information;
+
+        renderTwigForm($form, $additionnalHtml, $this->fields);
         return true;
     }
 


### PR DESCRIPTION
This commit adds back `autoinventory_information` hook implementations to various objects