### PR TITLE
fix(ma,lock): invalid types

### DIFF
--- a/inc/lock.class.php
+++ b/inc/lock.class.php
@@ -598,7 +598,7 @@ class Lock extends CommonGLPI
         array &$actions,
         $itemtype,
         $is_deleted = 0,
-        CommonDBTM $checkitem = null
+        CommonDBTM|null $checkitem = null
     ) {
 
         $action_name = __CLASS__ . MassiveAction::CLASS_ACTION_SEPARATOR . 'unlock';

--- a/inc/massiveaction.class.php
+++ b/inc/massiveaction.class.php
@@ -507,12 +507,12 @@ class MassiveAction
      *
      * @param string|CommonDBTM $item        the item for which we want the massive actions
      * @param boolean           $is_deleted  massive action for deleted items ?   (default 0)
-     * @param CommonDBTM        $checkitem   link item to check right              (default NULL)
+     * @param CommonDBTM        $checkitem   link item to check right             (default NULL)
      * @param integer|boolean   $single      Get actions for a single item
      *
-     * @return array of massive actions or false if $item is not valid
+     * @return array|bool of massive actions or false if $item is not valid
     **/
-    public static function getAllMassiveActions($item, $is_deleted = 0, CommonDBTM $checkitem = null, $single = false)
+    public static function getAllMassiveActions($item, $is_deleted = 0, CommonDBTM|null $checkitem = null, $single = false)
     {
         global $PLUGIN_HOOKS;
 


### PR DESCRIPTION
Fix type declaration on massiveaction & lock related functions to prevent warnings