### PR TITLE
fix(ticket): allow validation of ticket creation in helpdesk mode

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -838,7 +838,7 @@ abstract class CommonITILObject extends CommonDBTM
                 }
 
                 // Can only update initial fields if no followup or task already added
-                if ($this->canUpdateItem()) {
+                if ($this->canUpdateItem() || ($this->canCreateItem() && Session::getCurrentInterface() == "helpdesk")) {
                     $allowed_fields[] = 'content';
                     $allowed_fields[] = 'urgency';
                     $allowed_fields[] = 'priority'; // automatic recalculate if user changes urgence


### PR DESCRIPTION
It was previously not possible for tickets to be created by a user, even on behalf of a plugin if they had their interface set to selfservice.
This issue would result in null tickets, which cause stability issues.