### PR TITLE
Fix for Overwritten property

### DIFF
--- a/lib/jqueryplugins/jquery-ui-scrollable-tabs/js/jquery.scrollabletab.js
+++ b/lib/jqueryplugins/jquery-ui-scrollable-tabs/js/jquery.scrollabletab.js
@@ -40,7 +40,6 @@ TODO:
         'customNavFirst': null,
         'customNavLast': null,
         'closable': false, //Make tabs closable
-        'easing': '',
         'easing': 'swing', //The easing equation
         'loadLastTab': false, //When tabs loaded, scroll to the last tab - default is the first tab
         'navFirstIconClass': 'ui-icon-arrowthickstop-1-w',


### PR DESCRIPTION
Remove the duplicate `'easing'` property from the `settings` object so only one `'easing'` key remains.

Best fix (no functionality change): delete line 43 (`'easing': ''`) and keep line 44 (`'easing': 'swing'`) since that is the effective runtime value today. This preserves behavior exactly while resolving the CodeQL finding and improving readability.

File/region to update:
- `lib/jqueryplugins/jquery-ui-scrollable-tabs/js/jquery.scrollabletab.js`
- In the top-level `settings` object around lines 43–44.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._