### PR TITLE
feat(ticket): hide private followups/tasks from requesters

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -253,6 +253,98 @@ abstract class CommonITILObject extends CommonDBTM
     }
 
     /**
+     * Check if private ticket content must be hidden for current user.
+     * Applies only to tickets and requester-side access without support-side access.
+     *
+     * @return bool
+     */
+    public function shouldHidePrivateTicketContentFromCurrentUser(): bool
+    {
+        if (
+            !$this instanceof Ticket
+            || !isset($this->fields['entities_id'])
+            || (int)Entity::getUsedConfig('requesters_private_ticket_content', (int)$this->fields['entities_id']) !== 1
+        ) {
+            return false;
+        }
+
+        $user_id = Session::getLoginUserID();
+        if ((int)$user_id <= 0) {
+            return false;
+        }
+
+        $is_requester_side = $this->isUser(CommonITILActor::REQUESTER, $user_id)
+            || (
+                isset($_SESSION['glpigroups'])
+                && $this->haveAGroup(CommonITILActor::REQUESTER, $_SESSION['glpigroups'])
+            );
+        if (!$is_requester_side) {
+            return false;
+        }
+
+        $has_support_side_access = Session::haveRight(Ticket::$rightname, Ticket::READALL)
+            || Session::haveRight(Ticket::$rightname, Ticket::READASSIGN)
+            || $this->isUser(CommonITILActor::ASSIGN, $user_id)
+            || (
+                isset($_SESSION['glpigroups'])
+                && $this->haveAGroup(CommonITILActor::ASSIGN, $_SESSION['glpigroups'])
+            );
+
+        return !$has_support_side_access;
+    }
+
+    /**
+     * Check if current user can access private ITIL content for current item.
+     * Combines private right and ticket requester-side policy.
+     *
+     * @param string $rightname
+     * @param int    $private_right
+     *
+     * @return bool
+     */
+    public function canCurrentUserAccessPrivateITILContent(string $rightname, int $private_right): bool
+    {
+        return Session::haveRight($rightname, $private_right)
+            && !$this->shouldHidePrivateTicketContentFromCurrentUser();
+    }
+
+    /**
+     * Get SQL criteria used to restrict private ITIL content visibility for current user.
+     *
+     * @param string $rightname
+     * @param int    $private_right
+     * @param bool   $allow_own_private
+     * @param int    $owner_users_id
+     *
+     * @return array
+     */
+    public function getCurrentUserPrivateITILContentRestriction(
+        string $rightname,
+        int $private_right,
+        bool $allow_own_private = true,
+        int $owner_users_id = 0
+    ): array {
+        if ($this->canCurrentUserAccessPrivateITILContent($rightname, $private_right)) {
+            return [];
+        }
+
+        if ($this->shouldHidePrivateTicketContentFromCurrentUser()) {
+            return ['is_private' => 0];
+        }
+
+        if ($allow_own_private) {
+            return [
+               'OR' => [
+                  'is_private' => 0,
+                  'users_id'   => $owner_users_id > 0 ? $owner_users_id : Session::getLoginUserID(),
+               ]
+            ];
+        }
+
+        return ['is_private' => 0];
+    }
+
+    /**
      * Check if the given users is a validator
      * @param int $users_id
      * @return bool
@@ -7373,7 +7465,6 @@ abstract class CommonITILObject extends CommonDBTM
 
         $candelete   = static::canDelete();
         $canupdate   = Session::haveRight(static::$rightname, UPDATE);
-        $showprivate = Session::haveRight('followup', ITILFollowup::SEEPRIVATE);
         $align       = "class='left'";
         $align_desc  = "class='left";
 
@@ -7610,8 +7701,18 @@ abstract class CommonITILObject extends CommonDBTM
                         $eigth_column,
                         sprintf(
                             __('%1$s - %2$s'),
-                            $item->numberOfFollowups($showprivate),
-                            $item->numberOfTasks($showprivate)
+                            $item->numberOfFollowups(
+                                $item->canCurrentUserAccessPrivateITILContent(
+                                    ITILFollowup::$rightname,
+                                    ITILFollowup::SEEPRIVATE
+                                )
+                            ),
+                            $item->numberOfTasks(
+                                $item->canCurrentUserAccessPrivateITILContent(
+                                    ITILFollowup::$rightname,
+                                    ITILFollowup::SEEPRIVATE
+                                )
+                            )
                         )
                     );
                 }
@@ -8265,11 +8366,22 @@ abstract class CommonITILObject extends CommonDBTM
 
         //checks rights
         $restrict_fup = $restrict_task = [];
-        if (!Session::haveRight("followup", ITILFollowup::SEEPRIVATE)) {
+        $must_hide_private_ticket_content = $this->shouldHidePrivateTicketContentFromCurrentUser();
+        $can_view_private_followups = $this->canCurrentUserAccessPrivateITILContent(
+            ITILFollowup::$rightname,
+            ITILFollowup::SEEPRIVATE
+        );
+        $can_view_private_tasks = $this->canCurrentUserAccessPrivateITILContent(
+            $task_obj::$rightname,
+            CommonITILTask::SEEPRIVATE
+        );
+        if ($must_hide_private_ticket_content) {
+            $restrict_fup = ['is_private' => 0];
+        } elseif (!$can_view_private_followups) {
             $restrict_fup = [
                'OR' => [
-                  'is_private'   => 0,
-                  'users_id'     => Session::getLoginUserID()
+                  'is_private' => 0,
+                  'users_id'   => Session::getLoginUserID()
                ]
             ];
         }
@@ -8277,15 +8389,19 @@ abstract class CommonITILObject extends CommonDBTM
         $restrict_fup['itemtype'] = static::getType();
         $restrict_fup['items_id'] = $this->getID();
 
-        if ($task_obj->maybePrivate() && !Session::haveRight("task", CommonITILTask::SEEPRIVATE)) {
-            $restrict_task = [
-               'OR' => [
-                  'is_private'   => 0,
-                  'users_id'     => Session::getCurrentInterface() == "central"
-                                       ? Session::getLoginUserID()
-                                       : 0
-               ]
-            ];
+        if ($task_obj->maybePrivate()) {
+            if ($must_hide_private_ticket_content) {
+                $restrict_task = ['is_private' => 0];
+            } elseif (!$can_view_private_tasks) {
+                $restrict_task = [
+                   'OR' => [
+                      'is_private' => 0,
+                      'users_id'   => Session::getCurrentInterface() == "central"
+                          ? Session::getLoginUserID()
+                          : 0
+                   ]
+                ];
+            }
         }
 
         //add followups to timeline
@@ -9643,6 +9759,8 @@ abstract class CommonITILObject extends CommonDBTM
     public function getAssociatedDocumentsCriteria($bypass_rights = false): array
     {
         $task_class = $this->getType() . 'Task';
+        $must_hide_private_ticket_content = !$bypass_rights
+            && $this->shouldHidePrivateTicketContentFromCurrentUser();
 
         $or_crits = [
            // documents associated to ITIL item directly
@@ -9658,7 +9776,13 @@ abstract class CommonITILObject extends CommonDBTM
                ITILFollowup::getTableField('itemtype') => $this->getType(),
                ITILFollowup::getTableField('items_id') => $this->getID(),
             ];
-            if (!$bypass_rights && !Session::haveRight(ITILFollowup::$rightname, ITILFollowup::SEEPRIVATE)) {
+            $can_view_private_followups = $this->canCurrentUserAccessPrivateITILContent(
+                ITILFollowup::$rightname,
+                ITILFollowup::SEEPRIVATE
+            );
+            if ($must_hide_private_ticket_content) {
+                $fup_crits['is_private'] = 0;
+            } elseif (!$bypass_rights && !$can_view_private_followups) {
                 $fup_crits[] = [
                    'OR' => ['is_private' => 0, 'users_id' => Session::getLoginUserID()],
                 ];
@@ -9697,7 +9821,13 @@ abstract class CommonITILObject extends CommonDBTM
             $tasks_crit = [
                $this->getForeignKeyField() => $this->getID(),
             ];
-            if (!$bypass_rights && !Session::haveRight($task_class::$rightname, CommonITILTask::SEEPRIVATE)) {
+            $can_view_private_tasks = $this->canCurrentUserAccessPrivateITILContent(
+                $task_class::$rightname,
+                CommonITILTask::SEEPRIVATE
+            );
+            if ($must_hide_private_ticket_content) {
+                $tasks_crit['is_private'] = 0;
+            } elseif (!$bypass_rights && !$can_view_private_tasks) {
                 $tasks_crit[] = [
                    'OR' => ['is_private' => 0, 'users_id' => Session::getLoginUserID()],
                 ];

--- a/inc/commonitiltask.class.php
+++ b/inc/commonitiltask.class.php
@@ -206,15 +206,21 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
             $nb = 0;
             if ($_SESSION['glpishow_count_on_tabs']) {
                 $restrict = [$item->getForeignKeyField() => $item->getID()];
+                $must_hide_private_ticket_content = $item instanceof Ticket
+                    && $item->shouldHidePrivateTicketContentFromCurrentUser();
 
                 if (
                     $this->maybePrivate()
-                    && !$this->canViewPrivates()
+                    && ($must_hide_private_ticket_content || !$this->canViewPrivates())
                 ) {
-                    $restrict['OR'] = [
-                       'is_private'   => 0,
-                       'users_id'     => Session::getLoginUserID()
-                    ];
+                    if ($must_hide_private_ticket_content) {
+                        $restrict['is_private'] = 0;
+                    } else {
+                        $restrict['OR'] = [
+                           'is_private' => 0,
+                           'users_id'   => Session::getLoginUserID()
+                        ];
+                    }
                 }
                 $nb = countElementsInTable($this->getTable(), $restrict);
             }
@@ -295,6 +301,14 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
             && !$input["_job"]->getFromDB($input[$input["_job"]->getForeignKeyField()])
         ) {
             return false;
+        }
+        if (
+            isset($input['is_private'])
+            && $input["_job"] instanceof Ticket
+            && $input["_job"]->shouldHidePrivateTicketContentFromCurrentUser()
+            && (int)$input['is_private'] === 1
+        ) {
+            $input['is_private'] = 0;
         }
 
         if (isset($input["plan"])) {
@@ -518,6 +532,13 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
             $input["date"] = $_SESSION["glpi_currenttime"];
         }
         if (!isset($input["is_private"])) {
+            $input['is_private'] = 0;
+        }
+        if (
+            $input["_job"] instanceof Ticket
+            && $input["_job"]->shouldHidePrivateTicketContentFromCurrentUser()
+            && (int)$input['is_private'] === 1
+        ) {
             $input['is_private'] = 0;
         }
 
@@ -1600,6 +1621,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
         $canplan = (!$item->isStatusExists(CommonITILObject::PLANNED)
             || $item->isAllowedStatus($item->fields['status'], CommonITILObject::PLANNED));
         $rand = mt_rand();
+        $hide_private_for_requester = $item->shouldHidePrivateTicketContentFromCurrentUser();
 
         $planLabel = __('Plan this task');
 
@@ -1630,6 +1652,11 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
                        'name' => $fkfield,
                        'value' => $this->fields[$fkfield],
                     ],
+                    $hide_private_for_requester ? [
+                       'type' => 'hidden',
+                       'name' => 'is_private',
+                       'value' => 0,
+                    ] : [],
                     '' => [
                        'type' => 'richtextarea',
                        'name' => 'content',
@@ -1711,7 +1738,7 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
                        ],
                        'value' => Planning::TODO,
                     ] : [],
-                    __('Private') => ($this->maybePrivate()) ? [
+                    __('Private') => ($this->maybePrivate() && !$hide_private_for_requester) ? [
                        'type' => 'checkbox',
                        'id' => 'checkboxForIsPrivate',
                        'name' => 'is_private',
@@ -1780,27 +1807,29 @@ abstract class CommonITILTask extends CommonDBTM implements CalDAVCompatibleItem
               ]
            ]
         ];
-        $entity = Session::getActiveEntity();
-        echo Html::scriptBlock(
-            <<<JS
-         function showPlanUpdate{$rand}() {
-            $.ajax({
-               url: "{$CFG_GLPI["root_doc"]}/ajax/planning.php",
-               type: "POST",
-               data: {
-                  action: 'add_event_classic_form',
-                  form: 'followups',
-                  entity: {$entity},
-                  itemtype: 'TicketTask',
-                  items_id: {$item->getID()}
-               }
+        if ($canplan && !isCommandLine()) {
+            $entity = Session::getActiveEntity();
+            echo Html::scriptBlock(
+                <<<JS
+             function showPlanUpdate{$rand}() {
+                $.ajax({
+                   url: "{$CFG_GLPI["root_doc"]}/ajax/planning.php",
+                   type: "POST",
+                   data: {
+                      action: 'add_event_classic_form',
+                      form: 'followups',
+                      entity: {$entity},
+                      itemtype: 'TicketTask',
+                      items_id: {$item->getID()}
+                   }
+                 }
+                ).done(function(data) {
+                   $('#plan{$rand}').replaceWith(data);
+                });
              }
-            ).done(function(data) {
-               $('#plan{$rand}').replaceWith(data);
-            });
-         }
-      JS
-        );
+          JS
+            );
+        }
         renderTwigForm($form, '', $this->fields);
         return true;
     }

--- a/inc/define.php
+++ b/inc/define.php
@@ -33,7 +33,7 @@
 
 // Last version of GLPI only for plugin compatibility
 define('GLPI_VERSION', '9.5.13');
-define('ITSM_VERSION', '2.1.3');
+define('ITSM_VERSION', '2.1.4');
 if (substr(ITSM_VERSION, -4) === '-dev') {
     //for dev version
     define('ITSM_PREVER', str_replace('-dev', '', ITSM_VERSION));
@@ -43,7 +43,7 @@ if (substr(ITSM_VERSION, -4) === '-dev') {
     );
 } else {
     //for stable version
-    define("ITSM_SCHEMA_VERSION", '2.1.3');
+    define("ITSM_SCHEMA_VERSION", '2.1.4');
 }
 
 // Current version of ITSM-NG

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -114,7 +114,8 @@ class Entity extends CommonTreeDropdown
           'inquest_duration','inquest_URL',
           'max_closedate', 'tickettemplates_id',
           'changetemplates_id', 'problemtemplates_id',
-          'suppliers_as_private', 'autopurge_delay', 'anonymize_support_agents'
+          'suppliers_as_private', 'autopurge_delay', 'anonymize_support_agents',
+          'requesters_private_ticket_content'
        ],
        // Configuration
        'config' => ['enable_custom_css', 'custom_css_code']
@@ -2353,6 +2354,10 @@ class Entity extends CommonTreeDropdown
         if ($ID == 0) { // Remove parent option for root entity
             unset($anonymizeValues[self::CONFIG_PARENT]);
         }
+        $hidePrivateTicketContentValues = self::getHidePrivateTicketContentForRequestersValues();
+        if ($ID == 0) { // Remove parent option for root entity
+            unset($hidePrivateTicketContentValues[self::CONFIG_PARENT]);
+        }
 
         $form = [
            'action' => $canedit ? Toolbox::getItemTypeFormURL(__CLASS__) : '',
@@ -2459,6 +2464,15 @@ class Entity extends CommonTreeDropdown
                        'col_lg' => 6,
                        'after' => ($ID > 0 && ($entity->getField('anonymize_support_agents') == self::CONFIG_PARENT)) ?
                                   self::inheritedValue(self::getSpecificValueToDisplay('anonymize_support_agents', ['anonymize_support_agents' => self::getUsedConfig('anonymize_support_agents', $ID)]), false, false) : '',
+                  ],
+                  __('Hide private followups and tasks from requesters') => [
+                       'type'  => 'select',
+                       'name'  => 'requesters_private_ticket_content',
+                       'value' => $entity->fields['requesters_private_ticket_content'],
+                       'values' => $hidePrivateTicketContentValues,
+                       'col_lg' => 6,
+                       'after' => ($ID > 0 && ($entity->getField('requesters_private_ticket_content') == self::CONFIG_PARENT)) ?
+                                  self::inheritedValue(self::getSpecificValueToDisplay('requesters_private_ticket_content', ['requesters_private_ticket_content' => self::getUsedConfig('requesters_private_ticket_content', $ID)]), false, false) : '',
                   ],
                ]
               ],
@@ -2821,6 +2835,21 @@ class Entity extends CommonTreeDropdown
      * @return array
     **/
     public static function getAnonymizeSupportAgentsValues()
+    {
+
+        return [
+           self::CONFIG_PARENT => __('Inheritance of the parent entity'),
+           0 => __('No'),
+           1 => __('Yes'),
+        ];
+    }
+
+    /**
+     * Get values for requesters_private_ticket_content
+     *
+     * @return array
+    **/
+    public static function getHidePrivateTicketContentForRequestersValues()
     {
 
         return [

--- a/inc/itilfollowup.class.php
+++ b/inc/itilfollowup.class.php
@@ -122,7 +122,18 @@ class ITILFollowup extends CommonDBChild
         if (!$itilobject->can($this->getField('items_id'), READ)) {
             return false;
         }
-        if (Session::haveRight(self::$rightname, self::SEEPRIVATE)) {
+
+        $can_view_private = $itilobject->canCurrentUserAccessPrivateITILContent(
+            self::$rightname,
+            self::SEEPRIVATE
+        );
+        if (
+            $itilobject->shouldHidePrivateTicketContentFromCurrentUser()
+            && (int)$this->fields['is_private'] === 1
+        ) {
+            return false;
+        }
+        if ($can_view_private) {
             return true;
         }
         if (
@@ -172,6 +183,12 @@ class ITILFollowup extends CommonDBChild
         if (!$itilobject->can($this->getField('items_id'), READ)) {
             return false;
         }
+        if (
+            $itilobject->shouldHidePrivateTicketContentFromCurrentUser()
+            && (int)$this->fields['is_private'] === 1
+        ) {
+            return false;
+        }
 
         if (Session::haveRight(self::$rightname, PURGE)) {
             return true;
@@ -193,6 +210,12 @@ class ITILFollowup extends CommonDBChild
 
         $itilobject = new $this->fields['itemtype']();
         if (!$itilobject->can($this->getField('items_id'), READ)) {
+            return false;
+        }
+        if (
+            $itilobject->shouldHidePrivateTicketContentFromCurrentUser()
+            && (int)$this->fields['is_private'] === 1
+        ) {
             return false;
         }
 
@@ -436,6 +459,13 @@ class ITILFollowup extends CommonDBChild
         if (!isset($input["is_private"])) {
             $input['is_private'] = 0;
         }
+        if (
+            $input["_job"] instanceof Ticket
+            && $input["_job"]->shouldHidePrivateTicketContentFromCurrentUser()
+            && (int)$input['is_private'] === 1
+        ) {
+            $input['is_private'] = 0;
+        }
 
         if (isset($input["add_reopen"])) {
             if ($input["content"] == '') {
@@ -488,6 +518,15 @@ class ITILFollowup extends CommonDBChild
             && isset($input['content']) && ($input['content'] != $this->fields['content'])
         ) {
             $input["users_id_editor"] = $uid;
+        }
+
+        if (
+            isset($input['is_private'])
+            && $input["_job"] instanceof Ticket
+            && $input["_job"]->shouldHidePrivateTicketContentFromCurrentUser()
+            && (int)$input['is_private'] === 1
+        ) {
+            $input['is_private'] = 0;
         }
 
         return $input;
@@ -889,6 +928,7 @@ class ITILFollowup extends CommonDBChild
         $requester = ($item->isUser(CommonITILActor::REQUESTER, Session::getLoginUserID())
                       || (isset($_SESSION["glpigroups"])
                           && $item->haveAGroup(CommonITILActor::REQUESTER, $_SESSION['glpigroups'])));
+        $hide_private_for_requester = $item->shouldHidePrivateTicketContentFromCurrentUser();
 
         $reopen_case = false;
         if ($this->isNewID($ID)) {
@@ -932,6 +972,11 @@ class ITILFollowup extends CommonDBChild
                            'name' => 'items_id',
                            'value' => $item->getID(),
                         ],
+                        $hide_private_for_requester ? [
+                           'type' => 'hidden',
+                           'name' => 'is_private',
+                           'value' => 0,
+                        ] : [],
                         $reopen_case ? [
                            'type' => 'hidden',
                            'name' => 'add_reopen',
@@ -984,12 +1029,12 @@ class ITILFollowup extends CommonDBChild
                            'values' => getOptionForItems(RequestType::class, ['is_active' => 1, 'is_itilfollowup' => 1]),
                            'actions' => getItemActionButtons(['info', 'add'], RequestType::class),
                         ],
-                        __('Private') => [
+                        __('Private') => !$hide_private_for_requester ? [
                            'type' => 'checkbox',
                            'id' => 'is_privateswitch',
                            'name' => 'is_private',
                            'value' => $this->fields["is_private"]
-                        ],
+                        ] : [],
                         sprintf(__('%1$s (%2$s)'), __('File'), Document::getMaxUploadSize()) => [
                            'type' => 'file',
                            'name' => 'files',
@@ -1136,10 +1181,19 @@ class ITILFollowup extends CommonDBChild
            'itemtype'  => $itemtype,
            'items_id'  => $ID
         ];
-        if (!$showprivate) {
+        if ($itemtype === Ticket::class) {
+            $ticket = new Ticket();
+                if ($ticket->getFromDB($ID)) {
+                $where += $ticket->getCurrentUserPrivateITILContentRestriction(
+                    self::$rightname,
+                    self::SEEPRIVATE,
+                    true
+                );
+            }
+        } elseif (!$showprivate) {
             $where['OR'] = [
-               'is_private'   => 0,
-               'users_id'     => Session::getLoginUserID()
+               'is_private' => 0,
+               'users_id'   => Session::getLoginUserID()
             ];
         }
 

--- a/inc/itilfollowup.class.php
+++ b/inc/itilfollowup.class.php
@@ -1183,7 +1183,7 @@ class ITILFollowup extends CommonDBChild
         ];
         if ($itemtype === Ticket::class) {
             $ticket = new Ticket();
-                if ($ticket->getFromDB($ID)) {
+            if ($ticket->getFromDB($ID)) {
                 $where += $ticket->getCurrentUserPrivateITILContentRestriction(
                     self::$rightname,
                     self::SEEPRIVATE,

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -6378,10 +6378,6 @@ class Ticket extends CommonITILObject
             ];
             $values = [];
             $job = new Ticket();
-            $showprivate = false;
-            if (Session::haveRight('followup', ITILFollowup::SEEPRIVATE)) {
-                $showprivate = true;
-            }
             while ($data = $iterator->next()) {
                 $newValue = [];
                 $rand = mt_rand();
@@ -6460,13 +6456,17 @@ class Ticket extends CommonITILObject
                     }
                     $link   .= "'>";
                     $link   .= "<span class='b'>" . $job->getNameID() . "</span></a>";
+                    $ticket_showprivate = $job->canCurrentUserAccessPrivateITILContent(
+                        ITILFollowup::$rightname,
+                        ITILFollowup::SEEPRIVATE
+                    );
                     $link    = sprintf(
                         __('%1$s (%2$s)'),
                         $link,
                         sprintf(
                             __('%1$s - %2$s'),
-                            $job->numberOfFollowups($showprivate),
-                            $job->numberOfTasks($showprivate)
+                            $job->numberOfFollowups($ticket_showprivate),
+                            $job->numberOfTasks($ticket_showprivate)
                         )
                     );
                     $content = Toolbox::unclean_cross_side_scripting_deep(html_entity_decode(
@@ -7007,11 +7007,6 @@ class Ticket extends CommonITILObject
         // Should be called in a <table>-segment
         // Print links or not in case of user view
         // Make new job object and fill it from database, if success, print it
-        $showprivate = false;
-        if (Session::haveRight('followup', ITILFollowup::SEEPRIVATE)) {
-            $showprivate = true;
-        }
-
         $job  = new self();
         $rand = mt_rand();
         if ($job->getFromDBwithData($ID, 0)) {
@@ -7087,13 +7082,17 @@ class Ticket extends CommonITILObject
             }
             $link   .= "'>";
             $link   .= "<span class='b'>" . $job->getNameID() . "</span></a>";
+            $ticket_showprivate = $job->canCurrentUserAccessPrivateITILContent(
+                ITILFollowup::$rightname,
+                ITILFollowup::SEEPRIVATE
+            );
             $link    = sprintf(
                 __('%1$s (%2$s)'),
                 $link,
                 sprintf(
                     __('%1$s - %2$s'),
-                    $job->numberOfFollowups($showprivate),
-                    $job->numberOfTasks($showprivate)
+                    $job->numberOfFollowups($ticket_showprivate),
+                    $job->numberOfTasks($ticket_showprivate)
                 )
             );
             $content = Toolbox::unclean_cross_side_scripting_deep(html_entity_decode(

--- a/inc/tickettask.class.php
+++ b/inc/tickettask.class.php
@@ -91,6 +91,15 @@ class TicketTask extends CommonITILTask
             return false;
         }
 
+        $ticket = new Ticket();
+        if (
+            $ticket->getFromDB($this->fields['tickets_id'])
+            && (int)$this->fields['is_private'] === 1
+            && $ticket->shouldHidePrivateTicketContentFromCurrentUser()
+        ) {
+            return false;
+        }
+
         if (Session::haveRight(self::$rightname, parent::SEEPRIVATE)) {
             return true;
         }
@@ -173,6 +182,12 @@ class TicketTask extends CommonITILTask
         ) {
             return false;
         }
+        if (
+            (int)$this->fields['is_private'] === 1
+            && $ticket->shouldHidePrivateTicketContentFromCurrentUser()
+        ) {
+            return false;
+        }
 
         if (
             ($this->fields["users_id"] != Session::getLoginUserID())
@@ -196,6 +211,12 @@ class TicketTask extends CommonITILTask
         if (
             $ticket->getFromDB($this->fields['tickets_id'])
             && in_array($ticket->fields['status'], $ticket->getClosedStatusArray())
+        ) {
+            return false;
+        }
+        if (
+            (int)$this->fields['is_private'] === 1
+            && $ticket->shouldHidePrivateTicketContentFromCurrentUser()
         ) {
             return false;
         }

--- a/inc/update.class.php
+++ b/inc/update.class.php
@@ -660,6 +660,11 @@ class Update extends CommonGLPI
                 update212to213();
 
                 // no break
+            case "2.1.3":
+                include_once "{$updir}itsm_update_213_214.php";
+                update213to214();
+
+                // no break
             case ITSM_VERSION:
             case ITSM_SCHEMA_VERSION:
                 break;

--- a/install/empty_data.php
+++ b/install/empty_data.php
@@ -2098,6 +2098,7 @@ $tables['glpi_entities'] = [
       'suppliers_as_private'                 => 0,
       'enable_custom_css'                    => 0,
       'anonymize_support_agents'             => 0,
+      'requesters_private_ticket_content'    => 0,
    ],
 ];
 

--- a/install/itsm_update_213_214.php
+++ b/install/itsm_update_213_214.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ * ITSM-NG
+ * Copyright (C) 2026 ITSM-NG and contributors.
+ *
+ * https://www.itsm-ng.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of ITSM-NG.
+ *
+ * ITSM-NG is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * ITSM-NG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with ITSM-NG. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+
+/**
+ * Update ITSM-NG from 2.1.3 to 2.1.4
+ *
+ * @return bool for success (will die for most error)
+ **/
+function update213to214(): bool
+{
+    /** @global Migration $migration */
+    global $DB, $migration;
+
+    if (!$DB->fieldExists('glpi_entities', 'requesters_private_ticket_content')) {
+        $migration->addField(
+            'glpi_entities',
+            'requesters_private_ticket_content',
+            'integer',
+            [
+               'after'     => 'anonymize_support_agents',
+               'value'     => -2,  // Inherit as default value
+               'update'    => 0,   // Not enabled for root entity
+               'condition' => 'WHERE `id` = 0',
+            ]
+        );
+    }
+
+    $migration->executeMigration();
+    return true;
+}

--- a/install/mysql/glpi-empty.sql
+++ b/install/mysql/glpi-empty.sql
@@ -2532,6 +2532,7 @@ CREATE TABLE `glpi_entities` (
   `autofill_decommission_date` varchar(255) COLLATE utf8_unicode_ci NOT NULL DEFAULT '-2',
   `suppliers_as_private` int(11) NOT NULL DEFAULT '-2',
   `anonymize_support_agents` int(11) NOT NULL DEFAULT '-2',
+  `requesters_private_ticket_content` int(11) NOT NULL DEFAULT '-2',
   `enable_custom_css` int(11) NOT NULL DEFAULT '-2',
   `custom_css_code` text COLLATE utf8_unicode_ci,
   `latitude` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,

--- a/tests/functional/Change.php
+++ b/tests/functional/Change.php
@@ -162,6 +162,51 @@ class Change extends DbTestCase
         $this->integer((int)$change->fields['actiontime'])->isEqualTo(0);
     }
 
+    public function testChangeFollowupFormKeepsPrivateToggle()
+    {
+        $this->login('itsm', 'itsm');
+
+        $change = new \Change();
+        $changes_id = $change->add([
+           'name'    => 'change followup private toggle',
+           'content' => 'ensure followup form still exposes private toggle on changes',
+        ]);
+        $this->integer($changes_id)->isGreaterThan(0);
+        $this->boolean($change->getFromDB($changes_id))->isTrue();
+
+        $_SESSION['_glpi_csrf_token'] = \Session::getNewCSRFToken();
+
+        ob_start();
+        $followup = new \ITILFollowup();
+        $followup->showForm(0, ['item' => $change]);
+        $output = ob_get_clean();
+
+        $this->integer(preg_match('/id=["\']is_privateswitch["\']/', $output))->isEqualTo(1);
+    }
+
+    public function testChangeTaskFormKeepsPrivateToggle()
+    {
+        $this->login('itsm', 'itsm');
+
+        $change = new \Change();
+        $changes_id = $change->add([
+           'name'    => 'change task private toggle',
+           'content' => 'ensure task form still exposes private toggle on changes',
+        ]);
+        $this->integer($changes_id)->isGreaterThan(0);
+        $this->boolean($change->getFromDB($changes_id))->isTrue();
+
+        $_SESSION['_glpi_csrf_token'] = \Session::getNewCSRFToken();
+
+        ob_start();
+        $task = new \ChangeTask();
+        $task->getEmpty();
+        $task->showForm(0, ['parent' => $change]);
+        $output = ob_get_clean();
+
+        $this->integer(preg_match('/id=["\']checkboxForIsPrivate["\']/', $output))->isEqualTo(1);
+    }
+
     public function testPrepareInputForAddTranslatesItilRequesterPayload()
     {
         $this->login();

--- a/tests/functional/Entity.php
+++ b/tests/functional/Entity.php
@@ -358,6 +358,49 @@ class Entity extends DbTestCase
 
     }
 
+    public function testGetUsedConfigHidePrivateTicketContentForRequesters()
+    {
+        $this->login();
+
+        $root    = getItemByTypeName('Entity', 'Root entity', true);
+        $parent  = getItemByTypeName('Entity', '_test_root_entity', true);
+        $child_1 = getItemByTypeName('Entity', '_test_child_1', true);
+        $child_2 = getItemByTypeName('Entity', '_test_child_2', true);
+
+        $entity = new \Entity();
+        $this->boolean($entity->update([
+           'id' => $root,
+           'requesters_private_ticket_content' => 0,
+        ]))->isTrue();
+        $this->integer((int)\Entity::getUsedConfig('requesters_private_ticket_content', $parent))->isEqualTo(0);
+        $this->integer((int)\Entity::getUsedConfig('requesters_private_ticket_content', $child_1))->isEqualTo(0);
+        $this->integer((int)\Entity::getUsedConfig('requesters_private_ticket_content', $child_2))->isEqualTo(0);
+
+        $this->boolean($entity->update([
+           'id' => $parent,
+           'requesters_private_ticket_content' => 1,
+        ]))->isTrue();
+        $this->integer((int)\Entity::getUsedConfig('requesters_private_ticket_content', $parent))->isEqualTo(1);
+        $this->integer((int)\Entity::getUsedConfig('requesters_private_ticket_content', $child_1))->isEqualTo(1);
+        $this->integer((int)\Entity::getUsedConfig('requesters_private_ticket_content', $child_2))->isEqualTo(1);
+
+        $this->boolean($entity->update([
+           'id' => $child_1,
+           'requesters_private_ticket_content' => 0,
+        ]))->isTrue();
+        $this->integer((int)\Entity::getUsedConfig('requesters_private_ticket_content', $parent))->isEqualTo(1);
+        $this->integer((int)\Entity::getUsedConfig('requesters_private_ticket_content', $child_1))->isEqualTo(0);
+        $this->integer((int)\Entity::getUsedConfig('requesters_private_ticket_content', $child_2))->isEqualTo(1);
+
+        $this->boolean($entity->update([
+           'id' => $child_2,
+           'requesters_private_ticket_content' => 0,
+        ]))->isTrue();
+        $this->integer((int)\Entity::getUsedConfig('requesters_private_ticket_content', $parent))->isEqualTo(1);
+        $this->integer((int)\Entity::getUsedConfig('requesters_private_ticket_content', $child_1))->isEqualTo(0);
+        $this->integer((int)\Entity::getUsedConfig('requesters_private_ticket_content', $child_2))->isEqualTo(0);
+    }
+
 
     protected function customCssProvider()
     {

--- a/tests/functional/Ticket.php
+++ b/tests/functional/Ticket.php
@@ -3811,6 +3811,48 @@ class Ticket extends DbTestCase
         );
     }
 
+    protected function setSelfServiceTaskRight(int $right): void
+    {
+        global $DB;
+
+        $DB->update(
+            'glpi_profilerights',
+            [
+               'rights' => $right
+            ],
+            [
+               'profiles_id' => getItemByTypeName('Profile', 'Self-Service', true),
+               'name'        => \TicketTask::$rightname,
+            ]
+        );
+    }
+
+    private function getSelfServiceRightValue(string $rightname): int
+    {
+        global $DB;
+
+        $iterator = $DB->request([
+           'SELECT' => ['rights'],
+           'FROM'   => 'glpi_profilerights',
+           'WHERE'  => [
+              'profiles_id' => getItemByTypeName('Profile', 'Self-Service', true),
+              'name'        => $rightname,
+           ]
+        ]);
+
+        $row = $iterator->next();
+        return (int)$row['rights'];
+    }
+
+    private function setEntityRequesterPrivateTicketContentPolicy(int $entities_id, int $value): void
+    {
+        $entity = new \Entity();
+        $this->boolean($entity->update([
+           'id' => $entities_id,
+           'requesters_private_ticket_content' => $value,
+        ]))->isTrue();
+    }
+
     public function testCanAddFollowupsAsAssigned()
     {
         $post_only_id = getItemByTypeName('User', 'post-only', true);
@@ -4012,6 +4054,531 @@ class Ticket extends DbTestCase
         $this->login('post-only', 'postonly');
         $this->boolean((bool)$ticket_unassigned->canAddFollowups())->isFalse();
         $this->boolean((bool)$ticket_assigned->canAddFollowups())->isTrue();
+    }
+
+    public function testRequesterCannotViewOrSetPrivateTicketFollowupWhenPolicyEnabled()
+    {
+        $this->login();
+
+        $entity_id = getItemByTypeName('Entity', '_test_root_entity', true);
+        $post_only_id = getItemByTypeName('User', 'post-only', true);
+        $old_followup_right = $this->getSelfServiceRightValue(\ITILFollowup::$rightname);
+
+        $entity = new \Entity();
+        $this->boolean($entity->getFromDB($entity_id))->isTrue();
+        $old_policy_value = (int)$entity->fields['requesters_private_ticket_content'];
+
+        try {
+            $this->setSelfServiceFollowupRight(
+                \ITILFollowup::SEEPUBLIC
+                | \ITILFollowup::SEEPRIVATE
+                | \ITILFollowup::ADDMYTICKET
+                | \ITILFollowup::UPDATEMY
+            );
+            $this->setEntityRequesterPrivateTicketContentPolicy($entity_id, 1);
+
+            $ticket = new \Ticket();
+            $ticket_id = (int)$ticket->add([
+               'name'                => 'requester private followup policy',
+               'content'             => 'requester private followup policy',
+               'entities_id'         => $entity_id,
+               '_users_id_requester' => $post_only_id,
+            ]);
+            $this->integer($ticket_id)->isGreaterThan(0);
+
+            $private_fup = new \ITILFollowup();
+            $private_fup_id = (int)$private_fup->add([
+               'itemtype'   => \Ticket::class,
+               'items_id'   => $ticket_id,
+               'content'    => 'private followup',
+               'is_private' => 1,
+            ]);
+            $this->integer($private_fup_id)->isGreaterThan(0);
+
+            $public_fup = new \ITILFollowup();
+            $public_fup_id = (int)$public_fup->add([
+               'itemtype'   => \Ticket::class,
+               'items_id'   => $ticket_id,
+               'content'    => 'public followup',
+               'is_private' => 0,
+            ]);
+            $this->integer($public_fup_id)->isGreaterThan(0);
+
+            $this->login('post-only', 'postonly');
+
+            $private_fup = new \ITILFollowup();
+            $this->boolean($private_fup->getFromDB($private_fup_id))->isTrue();
+            $this->boolean((bool)$private_fup->canViewItem())->isFalse();
+
+            $public_fup = new \ITILFollowup();
+            $this->boolean($public_fup->getFromDB($public_fup_id))->isTrue();
+            $this->boolean((bool)$public_fup->canViewItem())->isTrue();
+
+            $requester_fup = new \ITILFollowup();
+            $requester_fup_id = (int)$requester_fup->add([
+               'itemtype'   => \Ticket::class,
+               'items_id'   => $ticket_id,
+               'content'    => 'requester followup add private',
+               'is_private' => 1,
+            ]);
+            $this->integer($requester_fup_id)->isGreaterThan(0);
+            $this->boolean($requester_fup->getFromDB($requester_fup_id))->isTrue();
+            $this->integer((int)$requester_fup->fields['is_private'])->isEqualTo(0);
+
+            $this->boolean($requester_fup->update([
+               'id'         => $requester_fup_id,
+               'content'    => 'requester followup update private',
+               'is_private' => 1,
+            ]))->isTrue();
+            $this->boolean($requester_fup->getFromDB($requester_fup_id))->isTrue();
+            $this->integer((int)$requester_fup->fields['is_private'])->isEqualTo(0);
+        } finally {
+            $this->login();
+            $this->setSelfServiceFollowupRight($old_followup_right);
+            $this->setEntityRequesterPrivateTicketContentPolicy($entity_id, $old_policy_value);
+        }
+    }
+
+    public function testRequesterAssignedStillSeesPrivateTicketFollowupWhenPolicyEnabled()
+    {
+        $this->login();
+
+        $entity_id = getItemByTypeName('Entity', '_test_root_entity', true);
+        $post_only_id = getItemByTypeName('User', 'post-only', true);
+        $old_followup_right = $this->getSelfServiceRightValue(\ITILFollowup::$rightname);
+
+        $entity = new \Entity();
+        $this->boolean($entity->getFromDB($entity_id))->isTrue();
+        $old_policy_value = (int)$entity->fields['requesters_private_ticket_content'];
+
+        try {
+            $this->setSelfServiceFollowupRight(\ITILFollowup::SEEPUBLIC | \ITILFollowup::SEEPRIVATE);
+            $this->setEntityRequesterPrivateTicketContentPolicy($entity_id, 1);
+
+            $ticket = new \Ticket();
+            $ticket_id = (int)$ticket->add([
+               'name'                => 'mixed requester+assign private followup policy',
+               'content'             => 'mixed requester+assign private followup policy',
+               'entities_id'         => $entity_id,
+               '_users_id_requester' => $post_only_id,
+               '_users_id_assign'    => $post_only_id,
+            ]);
+            $this->integer($ticket_id)->isGreaterThan(0);
+
+            $fup = new \ITILFollowup();
+            $fup_id = (int)$fup->add([
+               'itemtype'   => \Ticket::class,
+               'items_id'   => $ticket_id,
+               'content'    => 'private followup for mixed actor',
+               'is_private' => 1,
+            ]);
+            $this->integer($fup_id)->isGreaterThan(0);
+
+            $this->login('post-only', 'postonly');
+            $fup = new \ITILFollowup();
+            $this->boolean($fup->getFromDB($fup_id))->isTrue();
+            $this->boolean((bool)$fup->canViewItem())->isTrue();
+        } finally {
+            $this->login();
+            $this->setSelfServiceFollowupRight($old_followup_right);
+            $this->setEntityRequesterPrivateTicketContentPolicy($entity_id, $old_policy_value);
+        }
+    }
+
+    public function testRequesterFollowupFormHidesPrivateToggleWhenPolicyEnabled()
+    {
+        $this->login();
+
+        $entity_id = getItemByTypeName('Entity', '_test_root_entity', true);
+        $post_only_id = getItemByTypeName('User', 'post-only', true);
+        $old_followup_right = $this->getSelfServiceRightValue(\ITILFollowup::$rightname);
+
+        $entity = new \Entity();
+        $this->boolean($entity->getFromDB($entity_id))->isTrue();
+        $old_policy_value = (int)$entity->fields['requesters_private_ticket_content'];
+
+        try {
+            $this->setSelfServiceFollowupRight(
+                \ITILFollowup::SEEPUBLIC
+                | \ITILFollowup::SEEPRIVATE
+                | \ITILFollowup::ADDMYTICKET
+                | \ITILFollowup::UPDATEMY
+            );
+            $this->setEntityRequesterPrivateTicketContentPolicy($entity_id, 1);
+
+            $ticket = new \Ticket();
+            $ticket_id = (int)$ticket->add([
+               'name'                => 'requester followup form private policy',
+               'content'             => 'requester followup form private policy',
+               'entities_id'         => $entity_id,
+               '_users_id_requester' => $post_only_id,
+            ]);
+            $this->integer($ticket_id)->isGreaterThan(0);
+            $this->boolean($ticket->getFromDB($ticket_id))->isTrue();
+
+            $this->login('post-only', 'postonly');
+            $_SESSION['_glpi_csrf_token'] = \Session::getNewCSRFToken();
+
+            ob_start();
+            $followup = new \ITILFollowup();
+            $followup->showForm(0, ['item' => $ticket]);
+            $output = ob_get_clean();
+
+            $this->integer(preg_match('/id=["\']is_privateswitch["\']/', $output))->isEqualTo(0);
+        } finally {
+            $this->login();
+            $this->setSelfServiceFollowupRight($old_followup_right);
+            $this->setEntityRequesterPrivateTicketContentPolicy($entity_id, $old_policy_value);
+        }
+    }
+
+    public function testRequesterCannotViewOrSetPrivateTicketTaskWhenPolicyEnabled()
+    {
+        $this->login();
+
+        $entity_id = getItemByTypeName('Entity', '_test_root_entity', true);
+        $post_only_id = getItemByTypeName('User', 'post-only', true);
+        $old_task_right = $this->getSelfServiceRightValue(\TicketTask::$rightname);
+
+        $entity = new \Entity();
+        $this->boolean($entity->getFromDB($entity_id))->isTrue();
+        $old_policy_value = (int)$entity->fields['requesters_private_ticket_content'];
+
+        try {
+            $this->setSelfServiceTaskRight(
+                \TicketTask::SEEPUBLIC
+                | \TicketTask::SEEPRIVATE
+                | \TicketTask::ADDALLITEM
+            );
+            $this->setEntityRequesterPrivateTicketContentPolicy($entity_id, 1);
+
+            $ticket = new \Ticket();
+            $ticket_id = (int)$ticket->add([
+               'name'                => 'requester private task policy',
+               'content'             => 'requester private task policy',
+               'entities_id'         => $entity_id,
+               '_users_id_requester' => $post_only_id,
+            ]);
+            $this->integer($ticket_id)->isGreaterThan(0);
+
+            $private_task = new \TicketTask();
+            $private_task_id = (int)$private_task->add([
+               'tickets_id'  => $ticket_id,
+               'content'     => 'private task',
+               'is_private'  => 1,
+            ]);
+            $this->integer($private_task_id)->isGreaterThan(0);
+
+            $public_task = new \TicketTask();
+            $public_task_id = (int)$public_task->add([
+               'tickets_id'  => $ticket_id,
+               'content'     => 'public task',
+               'is_private'  => 0,
+            ]);
+            $this->integer($public_task_id)->isGreaterThan(0);
+
+            $this->login('post-only', 'postonly');
+
+            $private_task = new \TicketTask();
+            $this->boolean($private_task->getFromDB($private_task_id))->isTrue();
+            $this->boolean((bool)$private_task->canViewItem())->isFalse();
+
+            $public_task = new \TicketTask();
+            $this->boolean($public_task->getFromDB($public_task_id))->isTrue();
+            $this->boolean((bool)$public_task->canViewItem())->isTrue();
+
+            $requester_task = new \TicketTask();
+            $requester_task_id = (int)$requester_task->add([
+               'tickets_id' => $ticket_id,
+               'content'    => 'requester task add private',
+               'is_private' => 1,
+            ]);
+            $this->integer($requester_task_id)->isGreaterThan(0);
+            $this->boolean($requester_task->getFromDB($requester_task_id))->isTrue();
+            $this->integer((int)$requester_task->fields['is_private'])->isEqualTo(0);
+
+            $this->boolean($requester_task->update([
+               'id'         => $requester_task_id,
+               'tickets_id' => $ticket_id,
+               'content'    => 'requester task update private',
+               'is_private' => 1,
+            ]))->isTrue();
+            $this->boolean($requester_task->getFromDB($requester_task_id))->isTrue();
+            $this->integer((int)$requester_task->fields['is_private'])->isEqualTo(0);
+        } finally {
+            $this->login();
+            $this->setSelfServiceTaskRight($old_task_right);
+            $this->setEntityRequesterPrivateTicketContentPolicy($entity_id, $old_policy_value);
+        }
+    }
+
+    public function testRequesterTaskFormHidesPrivateToggleWhenPolicyEnabled()
+    {
+        $this->login();
+
+        $entity_id = getItemByTypeName('Entity', '_test_root_entity', true);
+        $post_only_id = getItemByTypeName('User', 'post-only', true);
+        $old_task_right = $this->getSelfServiceRightValue(\TicketTask::$rightname);
+
+        $entity = new \Entity();
+        $this->boolean($entity->getFromDB($entity_id))->isTrue();
+        $old_policy_value = (int)$entity->fields['requesters_private_ticket_content'];
+
+        try {
+            $this->setSelfServiceTaskRight(
+                \TicketTask::SEEPUBLIC
+                | \TicketTask::SEEPRIVATE
+                | \TicketTask::ADDALLITEM
+            );
+            $this->setEntityRequesterPrivateTicketContentPolicy($entity_id, 1);
+
+            $ticket = new \Ticket();
+            $ticket_id = (int)$ticket->add([
+               'name'                => 'requester task form private policy',
+               'content'             => 'requester task form private policy',
+               'entities_id'         => $entity_id,
+               '_users_id_requester' => $post_only_id,
+            ]);
+            $this->integer($ticket_id)->isGreaterThan(0);
+            $this->boolean($ticket->getFromDB($ticket_id))->isTrue();
+
+            $this->login('post-only', 'postonly');
+            $_SESSION['_glpi_csrf_token'] = \Session::getNewCSRFToken();
+
+            ob_start();
+            $task = new \TicketTask();
+            $task->getEmpty();
+            $task->showForm(0, ['parent' => $ticket]);
+            $output = ob_get_clean();
+
+            $this->integer(preg_match('/id=["\']checkboxForIsPrivate["\']/', $output))->isEqualTo(0);
+            $this->integer(
+                preg_match('/type=["\']hidden["\'][^>]*name=["\']is_private["\']|name=["\']is_private["\'][^>]*type=["\']hidden["\']/', $output)
+            )->isEqualTo(1);
+        } finally {
+            $this->login();
+            $this->setSelfServiceTaskRight($old_task_right);
+            $this->setEntityRequesterPrivateTicketContentPolicy($entity_id, $old_policy_value);
+        }
+    }
+
+    public function testRequesterAssignedStillSeesPrivateTicketTaskWhenPolicyEnabled()
+    {
+        $this->login();
+
+        $entity_id = getItemByTypeName('Entity', '_test_root_entity', true);
+        $post_only_id = getItemByTypeName('User', 'post-only', true);
+        $old_task_right = $this->getSelfServiceRightValue(\TicketTask::$rightname);
+
+        $entity = new \Entity();
+        $this->boolean($entity->getFromDB($entity_id))->isTrue();
+        $old_policy_value = (int)$entity->fields['requesters_private_ticket_content'];
+
+        try {
+            $this->setSelfServiceTaskRight(\TicketTask::SEEPUBLIC | \TicketTask::SEEPRIVATE);
+            $this->setEntityRequesterPrivateTicketContentPolicy($entity_id, 1);
+
+            $ticket = new \Ticket();
+            $ticket_id = (int)$ticket->add([
+               'name'                => 'mixed requester+assign private task policy',
+               'content'             => 'mixed requester+assign private task policy',
+               'entities_id'         => $entity_id,
+               '_users_id_requester' => $post_only_id,
+               '_users_id_assign'    => $post_only_id,
+            ]);
+            $this->integer($ticket_id)->isGreaterThan(0);
+
+            $task = new \TicketTask();
+            $task_id = (int)$task->add([
+               'tickets_id' => $ticket_id,
+               'content'    => 'private task for mixed actor',
+               'is_private' => 1,
+            ]);
+            $this->integer($task_id)->isGreaterThan(0);
+
+            $this->login('post-only', 'postonly');
+            $task = new \TicketTask();
+            $this->boolean($task->getFromDB($task_id))->isTrue();
+            $this->boolean((bool)$task->canViewItem())->isTrue();
+        } finally {
+            $this->login();
+            $this->setSelfServiceTaskRight($old_task_right);
+            $this->setEntityRequesterPrivateTicketContentPolicy($entity_id, $old_policy_value);
+        }
+    }
+
+    public function testTechnicianCanViewAndSetPrivateTicketFollowupWhenPolicyEnabled()
+    {
+        $this->login();
+
+        $entity_id = getItemByTypeName('Entity', '_test_root_entity', true);
+        $post_only_id = getItemByTypeName('User', 'post-only', true);
+
+        $entity = new \Entity();
+        $this->boolean($entity->getFromDB($entity_id))->isTrue();
+        $old_policy_value = (int)$entity->fields['requesters_private_ticket_content'];
+
+        try {
+            $this->setEntityRequesterPrivateTicketContentPolicy($entity_id, 1);
+
+            $ticket = new \Ticket();
+            $ticket_id = (int)$ticket->add([
+               'name'                => 'technician private followup policy',
+               'content'             => 'technician private followup policy',
+               'entities_id'         => $entity_id,
+               '_users_id_requester' => $post_only_id,
+            ]);
+            $this->integer($ticket_id)->isGreaterThan(0);
+            $this->boolean($ticket->getFromDB($ticket_id))->isTrue();
+
+            $private_fup = new \ITILFollowup();
+            $private_fup_id = (int)$private_fup->add([
+               'itemtype'   => \Ticket::class,
+               'items_id'   => $ticket_id,
+               'content'    => 'private followup for technician',
+               'is_private' => 1,
+            ]);
+            $this->integer($private_fup_id)->isGreaterThan(0);
+
+            $this->login('tech', 'tech');
+
+            $private_fup = new \ITILFollowup();
+            $this->boolean($private_fup->getFromDB($private_fup_id))->isTrue();
+            $this->boolean((bool)$private_fup->canViewItem())->isTrue();
+
+            $technician_fup = new \ITILFollowup();
+            $technician_fup_id = (int)$technician_fup->add([
+               'itemtype'   => \Ticket::class,
+               'items_id'   => $ticket_id,
+               'content'    => 'technician followup add private',
+               'is_private' => 1,
+            ]);
+            $this->integer($technician_fup_id)->isGreaterThan(0);
+            $this->boolean($technician_fup->getFromDB($technician_fup_id))->isTrue();
+            $this->integer((int)$technician_fup->fields['is_private'])->isEqualTo(1);
+
+            $_SESSION['_glpi_csrf_token'] = \Session::getNewCSRFToken();
+
+            ob_start();
+            $followup = new \ITILFollowup();
+            $followup->showForm(0, ['item' => $ticket]);
+            $output = ob_get_clean();
+
+            $this->integer(preg_match('/id=["\']is_privateswitch["\']/', $output))->isEqualTo(1);
+        } finally {
+            $this->login();
+            $this->setEntityRequesterPrivateTicketContentPolicy($entity_id, $old_policy_value);
+        }
+    }
+
+    public function testTechnicianCanViewAndSetPrivateTicketTaskWhenPolicyEnabled()
+    {
+        $this->login();
+
+        $entity_id = getItemByTypeName('Entity', '_test_root_entity', true);
+        $post_only_id = getItemByTypeName('User', 'post-only', true);
+
+        $entity = new \Entity();
+        $this->boolean($entity->getFromDB($entity_id))->isTrue();
+        $old_policy_value = (int)$entity->fields['requesters_private_ticket_content'];
+
+        try {
+            $this->setEntityRequesterPrivateTicketContentPolicy($entity_id, 1);
+
+            $ticket = new \Ticket();
+            $ticket_id = (int)$ticket->add([
+               'name'                => 'technician private task policy',
+               'content'             => 'technician private task policy',
+               'entities_id'         => $entity_id,
+               '_users_id_requester' => $post_only_id,
+            ]);
+            $this->integer($ticket_id)->isGreaterThan(0);
+            $this->boolean($ticket->getFromDB($ticket_id))->isTrue();
+
+            $private_task = new \TicketTask();
+            $private_task_id = (int)$private_task->add([
+               'tickets_id'  => $ticket_id,
+               'content'     => 'private task for technician',
+               'is_private'  => 1,
+            ]);
+            $this->integer($private_task_id)->isGreaterThan(0);
+
+            $this->login('tech', 'tech');
+
+            $private_task = new \TicketTask();
+            $this->boolean($private_task->getFromDB($private_task_id))->isTrue();
+            $this->boolean((bool)$private_task->canViewItem())->isTrue();
+
+            $technician_task = new \TicketTask();
+            $technician_task_id = (int)$technician_task->add([
+               'tickets_id' => $ticket_id,
+               'content'    => 'technician task add private',
+               'is_private' => 1,
+            ]);
+            $this->integer($technician_task_id)->isGreaterThan(0);
+            $this->boolean($technician_task->getFromDB($technician_task_id))->isTrue();
+            $this->integer((int)$technician_task->fields['is_private'])->isEqualTo(1);
+
+            $_SESSION['_glpi_csrf_token'] = \Session::getNewCSRFToken();
+
+            ob_start();
+            $task = new \TicketTask();
+            $task->getEmpty();
+            $task->showForm(0, ['parent' => $ticket]);
+            $output = ob_get_clean();
+
+            $this->integer(preg_match('/id=["\']checkboxForIsPrivate["\']/', $output))->isEqualTo(1);
+        } finally {
+            $this->login();
+            $this->setEntityRequesterPrivateTicketContentPolicy($entity_id, $old_policy_value);
+        }
+    }
+
+    public function testRequesterPolicyAppliesToAssociatedDocumentCriteria()
+    {
+        $this->login();
+
+        $entity_id = getItemByTypeName('Entity', '_test_root_entity', true);
+        $post_only_id = getItemByTypeName('User', 'post-only', true);
+        $old_followup_right = $this->getSelfServiceRightValue(\ITILFollowup::$rightname);
+        $old_task_right = $this->getSelfServiceRightValue(\TicketTask::$rightname);
+
+        $entity = new \Entity();
+        $this->boolean($entity->getFromDB($entity_id))->isTrue();
+        $old_policy_value = (int)$entity->fields['requesters_private_ticket_content'];
+
+        try {
+            $this->setSelfServiceFollowupRight(\ITILFollowup::SEEPUBLIC | \ITILFollowup::SEEPRIVATE);
+            $this->setSelfServiceTaskRight(\TicketTask::SEEPUBLIC | \TicketTask::SEEPRIVATE);
+            $this->setEntityRequesterPrivateTicketContentPolicy($entity_id, 1);
+
+            $ticket = new \Ticket();
+            $ticket_id = (int)$ticket->add([
+               'name'                => 'requester policy document criteria',
+               'content'             => 'requester policy document criteria',
+               'entities_id'         => $entity_id,
+               '_users_id_requester' => $post_only_id,
+            ]);
+            $this->integer($ticket_id)->isGreaterThan(0);
+
+            $this->login('post-only', 'postonly');
+            $this->boolean($ticket->getFromDB($ticket_id))->isTrue();
+
+            $crit = $ticket->getAssociatedDocumentsCriteria(false);
+            $it = new \DBmysqlIterator(null);
+            $it->execute('glpi_tickets', $crit);
+            $sql = $it->getSql();
+
+            $this->string($sql)->contains("FROM `glpi_itilfollowups` WHERE");
+            $this->string($sql)->contains("`glpi_itilfollowups`.`items_id` = '" . $ticket_id . "' AND `is_private` = '0'");
+            $this->string($sql)->contains("FROM `glpi_tickettasks` WHERE");
+            $this->string($sql)->contains("`tickets_id` = '" . $ticket_id . "' AND `is_private` = '0'");
+        } finally {
+            $this->login();
+            $this->setSelfServiceFollowupRight($old_followup_right);
+            $this->setSelfServiceTaskRight($old_task_right);
+            $this->setEntityRequesterPrivateTicketContentPolicy($entity_id, $old_policy_value);
+        }
     }
 
     protected function convertContentForTicketProvider(): iterable


### PR DESCRIPTION
Adds a helpdesk setting on entities that disallows requesters on tickets from creating private followups and tasks.