### PR TITLE
Fix/restore self assign button

### DIFF
--- a/inc/commonitilobject.class.php
+++ b/inc/commonitilobject.class.php
@@ -5108,6 +5108,11 @@ abstract class CommonITILObject extends CommonDBTM
             && !($hiddenFields['_users_id_assign'] ?? false)
             && !$this->isUser(CommonITILActor::ASSIGN, Session::getLoginUserID())
             && $assignAllowed;
+        $canSelfObserver = !$isNew
+            && !$isClosed
+            && !($hiddenFields['_users_id_observer'] ?? false)
+            && !$this->isUser(CommonITILActor::OBSERVER, Session::getLoginUserID())
+            && !$this->isUser(CommonITILActor::REQUESTER, Session::getLoginUserID());
 
         $roleDefinitions = [
             [
@@ -5132,6 +5137,7 @@ abstract class CommonITILObject extends CommonDBTM
                 'fields'       => ['_users_id_observer', '_groups_id_observer'],
                 'allowAdd'     => !$isClosed && $canAdmin,
                 'removable'    => !$isClosed && $canAdmin,
+                'selfAssign'   => $canSelfObserver,
                 'allowedTypes' => ['user', 'group'],
             ],
             [
@@ -5234,7 +5240,7 @@ abstract class CommonITILObject extends CommonDBTM
                 'selfAssign'  => !empty($panelDefinition['selfAssign']) ? [
                     'fieldName'  => $this->getForeignKeyField(),
                     'itemId'     => $ID,
-                    'buttonName' => 'addme_assign',
+                    'buttonName' => 'addme_' . $panelDefinition['actorType'],
                     'label'      => __('Associate myself'),
                 ] : null,
             ];

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -4989,6 +4989,11 @@ class Ticket extends CommonITILObject
             && !($hiddenFields['_users_id_assign'] ?? false)
             && !$this->isUser(CommonITILActor::ASSIGN, Session::getLoginUserID())
             && $assignAllowed;
+        $canSelfObserver = !$isNew
+            && !$isClosed
+            && !($hiddenFields['_users_id_observer'] ?? false)
+            && !$this->isUser(CommonITILActor::OBSERVER, Session::getLoginUserID())
+            && !$this->isUser(CommonITILActor::REQUESTER, Session::getLoginUserID());
 
         $roleDefinitions = [
             [
@@ -5015,6 +5020,7 @@ class Ticket extends CommonITILObject
                 'help'          => !$isNew && !$isClosed && $canAdmin ? __('New actors are added when you save the ticket.') : '',
                 'allowAdd'      => !$isClosed && $canAdmin,
                 'removable'     => !$isClosed && $canAdmin,
+                'selfAssign'    => $canSelfObserver,
                 'allowedTypes'  => ['user', 'group'],
             ],
             [
@@ -5120,7 +5126,7 @@ class Ticket extends CommonITILObject
                 'selfAssign'  => !empty($panelDefinition['selfAssign']) ? [
                     'fieldName'  => $this->getForeignKeyField(),
                     'itemId'     => $ID,
-                    'buttonName' => 'addme_assign',
+                    'buttonName' => 'addme_' . $panelDefinition['actorType'],
                     'label'      => __('Associate myself'),
                 ] : null,
             ];

--- a/templates/itil/actorPanel.twig
+++ b/templates/itil/actorPanel.twig
@@ -12,7 +12,6 @@
     }
 
     #{{ panel_id }} .itil-actor-card {
-      position: relative;
       border: 1px solid var(--tbl-border-color, #d9dee7);
       border-radius: 0.75rem;
       background: linear-gradient(180deg, #ffffff 0%, #f7f9fc 100%);
@@ -30,27 +29,6 @@
       justify-content: space-between;
       align-items: center;
       gap: 0.75rem;
-    }
-
-    #{{ panel_id }} .itil-actor-card__header-actions {
-      position: absolute;
-      top: 1rem;
-      right: 1rem;
-      line-height: 1;
-    }
-
-    #{{ panel_id }} .itil-actor-card__header-actions .icon-button {
-      border: 0;
-      background: transparent;
-      color: #5f6f86;
-      line-height: 1;
-      padding: 0;
-      cursor: pointer;
-    }
-
-    #{{ panel_id }} .itil-actor-card__header-actions .icon-button:hover,
-    #{{ panel_id }} .itil-actor-card__header-actions .icon-button:focus {
-      color: #102a56;
     }
 
     #{{ panel_id }} .itil-actor-card__title {
@@ -250,18 +228,13 @@
               {% endif %}
             </div>
             {% if panel.selfAssign %}
-              <div class="itil-actor-card__header-actions">
-                <input type="hidden"
-                       name="{{ panel.selfAssign.fieldName }}"
-                       value="{{ panel.selfAssign.itemId }}">
-                <button type="submit"
-                        name="{{ panel.selfAssign.buttonName }}"
-                        value="{{ panel.selfAssign.buttonName }}"
-                        class="icon-button"
-                        title="{{ panel.selfAssign.label }}"
-                        aria-label="{{ panel.selfAssign.label }}"
-                        formnovalidate>
-                  <i class="fas fa-male" aria-hidden="true"></i>
+              <div>
+                <button type="button"
+                        class="btn btn-sm btn-outline-secondary"
+                        title="{{ 'Associate myself'|trans }}"
+                        data-role="self-assign">
+                  <i class="fas fa-user-plus"></i>
+                  <span class="ms-1">{{ 'Associate myself'|trans }}</span>
                 </button>
               </div>
             {% endif %}
@@ -633,6 +606,25 @@
       }
 
       updateEmptyState();
+
+      // Bouton "M'associer"
+      $panel.on('click', '[data-role="self-assign"]', () => {
+        $.ajax({
+          url: `${rootDoc}/front/ticket.form.php`,
+          type: 'POST',
+          data: {
+            [itemtype.toLowerCase() + 's_id']: itemsId,
+            ['addme_' + role]: 1,
+            _glpi_csrf_token: $('input[name="_glpi_csrf_token"]').first().val(),
+          },
+          success: () => {
+            window.location.reload();
+          },
+          error: () => {
+            window.location.reload();
+          },
+        });
+      });
     });
   })();
 </script>


### PR DESCRIPTION
The "Assign to me" functionality was incomplete in the new actor panel interface, this PR restores the ability for a user with the correct permissions to assign a ticket to themselves directly from the ui

Changes made

templates/itil/actorPanel.twig : Added the ui element/button for self-assignment

src/commonitilobject.class.php & src/ticket.class.php : Updated backend logic to ensure the self-assignment action is properly processed and saved when triggered from the new panel
